### PR TITLE
add erc165 interface for extraBridgeData

### DIFF
--- a/boba_community/turing-monsters/contracts/AddOnChainMetaData.sol
+++ b/boba_community/turing-monsters/contracts/AddOnChainMetaData.sol
@@ -84,7 +84,7 @@ abstract contract AddOnChainMetaData is ERC721 {
         return abi.encode(_tokenURIs[tokenId]);
     }
 
-    function supportsInterface(bytes4 _interfaceId) public view override returns (bool) {
+    function supportsInterface(bytes4 _interfaceId) public view virtual override returns (bool) {
         return _interfaceId == this.bridgeExtraData.selector || super.supportsInterface(_interfaceId);
     }
 

--- a/boba_community/turing-monsters/contracts/AddOnChainMetaData.sol
+++ b/boba_community/turing-monsters/contracts/AddOnChainMetaData.sol
@@ -84,6 +84,10 @@ abstract contract AddOnChainMetaData is ERC721 {
         return abi.encode(_tokenURIs[tokenId]);
     }
 
+    function supportsInterface(bytes4 _interfaceId) public view override returns (bool) {
+        return _interfaceId == this.bridgeExtraData.selector || super.supportsInterface(_interfaceId);
+    }
+
     function _setTokenURI(uint256 tokenId_) internal virtual {
         require(_exists(tokenId_), "ERC721URIStorage: URI set of nonexistent token");
 

--- a/boba_community/turing-monsters/contracts/NFTMonsterV2.sol
+++ b/boba_community/turing-monsters/contracts/NFTMonsterV2.sol
@@ -105,6 +105,10 @@ contract NFTMonsterV2 is IERC2981, ERC721Burnable, ERC721Pausable, RandomlyAssig
         return AddOnChainMetaData.tokenURI(tokenId);
     }
 
+    function supportsInterface(bytes4 _interfaceId) public view override(IERC165, ERC721, AddOnChainMetaData) returns (bool) {
+        return AddOnChainMetaData.supportsInterface(_interfaceId);
+    }
+
     function _beforeTokenTransfer(
         address from,
         address to,

--- a/boba_community/turing-monsters/test/NFTMonsterV2.ts
+++ b/boba_community/turing-monsters/test/NFTMonsterV2.ts
@@ -237,6 +237,28 @@ describe("Turing bridgeable NFT Random 256", function () {
     expect(decodedMetadata['image_data']).to.contain('svg');
   })
 
+  it("should return bridgeExtraData", async () => {
+    const events = (await erc721.queryFilter(erc721.filters.MintedNFT()))
+    const tokenId_1 = events[0].args[0]
+    const tokenId_2 = events[1].args[0]
+
+    const bridgeExtraData_1 = await erc721.bridgeExtraData(tokenId_1)
+    console.log("Bridge Extra Data 1: ", bridgeExtraData_1)
+    const bridgeExtraData_2 = await erc721.bridgeExtraData(tokenId_2)
+    console.log("Bridge Extra Data 2: ", bridgeExtraData_2)
+
+    const decoded_1 = utils.defaultAbiCoder.decode(['uint256'], bridgeExtraData_1)
+    const decoded_2 = utils.defaultAbiCoder.decode(['uint256'], bridgeExtraData_2)
+
+    expect(bridgeExtraData_2).to.be.not.equal(bridgeExtraData_1)
+    expect(decoded_1).to.be.not.equal(decoded_2)
+  })
+
+  it("should support bridgeExtraData interface", async () => {
+    const extraDataInterface = '0x9b9284f9'
+    expect(await erc721.supportsInterface(extraDataInterface)).to.equal(true)
+  })
+
   it("should have different metadata", async () => {
 
     // DebugURI


### PR DESCRIPTION
adds the extraBridgeData to erc165 supportInterface to avoid assembly checking on nft bridges