### PR TITLE
Inomurko/retry ec2 stop step

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -273,11 +273,21 @@ jobs:
           aws-region: ${{ secrets.AWS_REGION }}
       - name: Stop EC2 runner
         uses: machulav/ec2-github-runner@v2
+        id: stop-ec2-runner
         with:
           mode: stop
           github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
           label: ${{ needs.start-runner.outputs.label }}
           ec2-instance-id: ${{ needs.start-runner.outputs.ec2-instance-id }}
+      - name: Stop EC2 runner
+        if: steps.stop-ec2-runner.outcome == 'failure'
+        uses: machulav/ec2-github-runner@v2
+        with:
+          mode: stop
+          github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
+          label: ${{ needs.start-runner.outputs.label }}
+          ec2-instance-id: ${{ needs.start-runner.outputs.ec2-instance-id }}
+
 
   stop-executioner:
     name: Stop self-hosted EC2 runner
@@ -316,7 +326,16 @@ jobs:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ secrets.AWS_REGION }}
-      - name: Stop EC2 runner
+      - name: Stop EC2 executioner
+        uses: machulav/ec2-github-runner@v2
+        id: stop-ec2-executioner
+        with:
+          mode: stop
+          github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
+          label: ${{ steps.runner_info.outputs.label }}
+          ec2-instance-id: ${{ steps.runner_info.outputs.ec2-instance-id }}
+      - name: Stop EC2 executioner
+        if: steps.stop-ec2-executioner.outcome == 'failure'
         uses: machulav/ec2-github-runner@v2
         with:
           mode: stop

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -280,6 +280,7 @@ jobs:
           label: ${{ needs.start-runner.outputs.label }}
           ec2-instance-id: ${{ needs.start-runner.outputs.ec2-instance-id }}
       - name: Sleep for 5 seconds
+        if: steps.stop-ec2-runner.outcome == 'failure'
         run: sleep 5s
         shell: bash
       - name: Stop EC2 runner
@@ -338,6 +339,7 @@ jobs:
           label: ${{ steps.runner_info.outputs.label }}
           ec2-instance-id: ${{ steps.runner_info.outputs.ec2-instance-id }}
       - name: Sleep for 5 seconds
+        if: steps.stop-ec2-executioner.outcome == 'failure'
         run: sleep 5s
         shell: bash
       - name: Stop EC2 executioner

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -279,6 +279,9 @@ jobs:
           github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
           label: ${{ needs.start-runner.outputs.label }}
           ec2-instance-id: ${{ needs.start-runner.outputs.ec2-instance-id }}
+      - name: Sleep for 5 seconds
+        run: sleep 5s
+        shell: bash
       - name: Stop EC2 runner
         if: steps.stop-ec2-runner.outcome == 'failure'
         uses: machulav/ec2-github-runner@v2
@@ -334,6 +337,9 @@ jobs:
           github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
           label: ${{ steps.runner_info.outputs.label }}
           ec2-instance-id: ${{ steps.runner_info.outputs.ec2-instance-id }}
+      - name: Sleep for 5 seconds
+        run: sleep 5s
+        shell: bash
       - name: Stop EC2 executioner
         if: steps.stop-ec2-executioner.outcome == 'failure'
         uses: machulav/ec2-github-runner@v2


### PR DESCRIPTION
Tackles https://github.com/bobanetwork/boba/issues/15
```
Finally, in about 1/4 of GH action runs, the integration tests fail to stop correctly:
```

so I've added a retry step with 5s delay, let's see if it's enough!