### PR TITLE
Fix the wrong l2BobaFee in receipt

### DIFF
--- a/integration-tests/test/boba-fee-payment.spec.ts
+++ b/integration-tests/test/boba-fee-payment.spec.ts
@@ -793,6 +793,28 @@ describe('Boba Fee Payment Integration Tests', async () => {
     ).to.be.rejectedWith('insufficient boba balance to pay for gas')
   })
 
+  it('{tag:boba} should return the correct receipt', async () => {
+    const randomWallet = ethers.Wallet.createRandom().connect(
+      env.l2Wallet.provider
+    )
+
+    const transferTx = await env.l2Wallet.sendTransaction({
+      to: randomWallet.address,
+      value: ethers.utils.parseEther('1'),
+    })
+    await transferTx.wait()
+
+    const registerTx = await Boba_GasPriceOracle.connect(
+      randomWallet
+    ).useBobaAsFeeToken()
+    await registerTx.wait()
+
+    const json = await env.l2Provider.send('eth_getTransactionReceipt', [
+      registerTx.hash,
+    ])
+    expect(json.l2BobaFee).to.deep.equal(BigNumber.from(0))
+  })
+
   describe('Meta transaction tests', async () => {
     let EIP712Domain: any
     let Permit: any

--- a/l2geth/core/state_processor.go
+++ b/l2geth/core/state_processor.go
@@ -124,6 +124,9 @@ func ApplyTransaction(config *params.ChainConfig, bc ChainContext, author *commo
 		}
 	}
 
+	// Determine the L2 Boba fee if users chose BOBA as the fee token
+	feeTokenSelection := statedb.GetFeeTokenSelection(msg.From())
+
 	// Apply the transaction to the current state (included in the env)
 	_, gas, failed, err := ApplyMessage(vmenv, msg, gp)
 
@@ -135,10 +138,8 @@ func ApplyTransaction(config *params.ChainConfig, bc ChainContext, author *commo
 		return nil, err
 	}
 
-	// Determine the L2 Boba fee if users chose BOBA as the fee token
-	// Otherwise, L2BobaFee = 0
+	// Calculate the boba fee related information that is to be included
 	L2BobaFee := new(big.Int)
-	feeTokenSelection := statedb.GetFeeTokenSelection(msg.From())
 	if feeTokenSelection.Cmp(common.Big1) == 0 {
 		bobaPriceRatio := statedb.GetBobaPriceRatio()
 		L2BobaFee = new(big.Int).Mul(big.NewInt(int64(gas)), new(big.Int).Mul(msg.GasPrice(), bobaPriceRatio))


### PR DESCRIPTION
We should check the fee token selection in `statedb` before the actual tx, so we can avoid the situation that users switch the fee token in this tx and the wrong `l2BobaFee` is written into the database.