### PR TITLE
brotli is implemented in zlib

### DIFF
--- a/packages/core-utils/package.json
+++ b/packages/core-utils/package.json
@@ -37,7 +37,6 @@
     "@ethersproject/providers": "^5.5.3",
     "@ethersproject/transactions": "^5.5.0",
     "@ethersproject/web": "^5.5.1",
-    "brotli": "^1.3.2",
     "bufio": "^1.0.7",
     "chai": "^4.3.4",
     "ethers": "^5.5.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6693,7 +6693,7 @@ base-x@^3.0.2, base-x@^3.0.8:
   dependencies:
     safe-buffer "^5.0.1"
 
-base64-js@^1.0.2, base64-js@^1.1.2, base64-js@^1.3.0, base64-js@^1.3.1:
+base64-js@^1.0.2, base64-js@^1.3.0, base64-js@^1.3.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
   integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
@@ -6956,13 +6956,6 @@ brorand@^1.0.1, brorand@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/brorand/-/brorand-1.1.0.tgz#12c25efe40a45e3c323eb8675a0a0ce57b22371f"
   integrity sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=
-
-brotli@^1.3.2:
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/brotli/-/brotli-1.3.2.tgz#525a9cad4fcba96475d7d388f6aecb13eed52f46"
-  integrity sha512-K0HNa0RRpUpcF8yS4yNSd6vmkrvA+wRd+symIcwhfqGLAi7YgGlKfO4oDYVgiahiLGNviO9uY7Zlb1MCPeTmSA==
-  dependencies:
-    base64-js "^1.1.2"
 
 browser-or-node@^1.3.0:
   version "1.3.0"


### PR DESCRIPTION
Why?
https://github.com/bobanetwork/boba/issues/213
Brotli was affecting how react app gateway was starting up.
How?
Use native zlib implementation of brotli. 
https://nodejs.org/api/zlib.html#zlibbrotlicompresssyncbuffer-options
https://nodejs.org/api/zlib.html#zlibbrotlidecompresssyncbuffer-options