### PR TITLE
applying the patch to develop for master release - bobasca/etherscan

### DIFF
--- a/packages/boba/contracts/contracts/oracle/README.md
+++ b/packages/boba/contracts/contracts/oracle/README.md
@@ -62,14 +62,14 @@ Note - It's highly recommended to obtain the feed addresses from the FeedRegsitr
 
 ### Rinkeby
 
-[ETH-USD](https://blockexplorer.rinkeby.boba.network/address/0xcEb40458ad6Dabe9cfC90A2ad062a071809c4E84/transactions) \
-[BOBA-USD](https://blockexplorer.rinkeby.boba.network/address/0xd05AA5531b8e8DaB3BEe675f133dF3e330d9adA8/transactions) \
+[ETH-USD](https://testnet.bobascan.com/address/0xcEb40458ad6Dabe9cfC90A2ad062a071809c4E84/transactions) \
+[BOBA-USD](https://testnet.bobascan.com/address/0xd05AA5531b8e8DaB3BEe675f133dF3e330d9adA8/transactions) \
 [OMG-USD]() \
 [WBTC-USD]()
 
 ### Mainnet
 
-[ETH-USD](https://blockexplorer.boba.network/address/0x50E383121021F4E8060C794d79Ada77195532c7a/transactions) \
-[BOBA-USD](https://blockexplorer.boba.network/address/0x987AEd89f5BDC3eb863282DBB76065bFe398be17/transactions) \
+[ETH-USD](https://bobascan.com/address/0x50E383121021F4E8060C794d79Ada77195532c7a/transactions) \
+[BOBA-USD](https://bobascan.com/address/0x987AEd89f5BDC3eb863282DBB76065bFe398be17/transactions) \
 [OMG-USD]() \
 [WBTC-USD]()

--- a/packages/boba/contracts/contracts/oracle/README.md
+++ b/packages/boba/contracts/contracts/oracle/README.md
@@ -62,14 +62,14 @@ Note - It's highly recommended to obtain the feed addresses from the FeedRegsitr
 
 ### Rinkeby
 
-[ETH-USD](https://testnet.bobascan.com/address/0xcEb40458ad6Dabe9cfC90A2ad062a071809c4E84/transactions) \
-[BOBA-USD](https://testnet.bobascan.com/address/0xd05AA5531b8e8DaB3BEe675f133dF3e330d9adA8/transactions) \
+[ETH-USD](https://testnet.bobascan.com/address/0xcEb40458ad6Dabe9cfC90A2ad062a071809c4E84#transactions) \
+[BOBA-USD](https://testnet.bobascan.com/address/0xd05AA5531b8e8DaB3BEe675f133dF3e330d9adA8#transactions) \
 [OMG-USD]() \
 [WBTC-USD]()
 
 ### Mainnet
 
-[ETH-USD](https://bobascan.com/address/0x50E383121021F4E8060C794d79Ada77195532c7a/transactions) \
-[BOBA-USD](https://bobascan.com/address/0x987AEd89f5BDC3eb863282DBB76065bFe398be17/transactions) \
+[ETH-USD](https://bobascan.com/address/0x50E383121021F4E8060C794d79Ada77195532c7a#transactions) \
+[BOBA-USD](https://bobascan.com/address/0x987AEd89f5BDC3eb863282DBB76065bFe398be17#transactions) \
 [OMG-USD]() \
 [WBTC-USD]()

--- a/packages/boba/gateway/src/components/pageFooter/PageFooter.js
+++ b/packages/boba/gateway/src/components/pageFooter/PageFooter.js
@@ -81,7 +81,7 @@ const PageFooter = ({maintenance}) => {
             }}
           >BobaScope</S.FooterLink>
           <S.FooterLink
-            href="https://blockexplorer.boba.network"
+            href="https://bobascan.com"
             component="a"
             target="_blank"
             sx={{ whiteSpace: 'nowrap'}}

--- a/packages/boba/gateway/src/util/masterConfig.js
+++ b/packages/boba/gateway/src/util/masterConfig.js
@@ -37,8 +37,8 @@ if (process.env.REACT_APP_CHAIN === 'rinkeby') {
         chainId: 28,
         chainIdHex: '0x1C',
         rpcUrl: `https://rinkeby.boba.network`,
-        blockExplorer: `https://blockexplorer.rinkeby.boba.network/`,
-        transaction: `https://blockexplorer.rinkeby.boba.network/tx/`
+        blockExplorer: `https://testnet.bobascan.com/address/`,
+        transaction: `https://testnet.bobascan.com/address/tx/`
       },
       payloadForL1SecurityFee: {
         from: '0x122816e7A7AeB40601d0aC0DCAA8402F7aa4cDfA',
@@ -78,8 +78,8 @@ if (process.env.REACT_APP_CHAIN === 'rinkeby') {
         chainId: 288,
         chainIdHex: '0x120',
         rpcUrl: `https://mainnet.boba.network`,
-        blockExplorer: `https://blockexplorer.boba.network/`,
-        transaction: `https://blockexplorer.boba.network/tx/`,
+        blockExplorer: `https://bobascan.com/`,
+        transaction: `https://bobascan.com/tx/`,
       },
       payloadForL1SecurityFee: {
         from: '0x5E7a06025892d8Eef0b5fa263fA0d4d2E5C3B549',

--- a/packages/boba/gateway/src/util/masterConfig.js
+++ b/packages/boba/gateway/src/util/masterConfig.js
@@ -37,8 +37,8 @@ if (process.env.REACT_APP_CHAIN === 'rinkeby') {
         chainId: 28,
         chainIdHex: '0x1C',
         rpcUrl: `https://rinkeby.boba.network`,
-        blockExplorer: `https://testnet.bobascan.com/address/`,
-        transaction: `https://testnet.bobascan.com/address/tx/`
+        blockExplorer: `https://testnet.bobascan.com/`,
+        transaction: `https://testnet.bobascan.com/tx/`
       },
       payloadForL1SecurityFee: {
         from: '0x122816e7A7AeB40601d0aC0DCAA8402F7aa4cDfA',


### PR DESCRIPTION
inomurko/sahil-fix-udpate-blockexplore-url-to-bobascan

## Overview

With the release of Bobascan (Etherscan) fixing URLs in the Gateway and in Metamask.

## Changes

Pointing to Bobascan instead of our own Blockexplorer.

- Metamask config
- Urls in gateway

## Testing

/