### PR TITLE
AuthFaucet distributes BOBA now (redeployed since on develop + minor cleanup)

### DIFF
--- a/boba_community/turing-twitter/contracts/AuthenticatedFaucet.sol
+++ b/boba_community/turing-twitter/contracts/AuthenticatedFaucet.sol
@@ -53,6 +53,7 @@ contract AuthenticatedFaucet is Ownable {
     /// @param twitterPostID_: Tweet ID with the assigned ID.
     function sendFunds(address to_, string calldata twitterPostID_) public {
         require(address(this).balance >= testnetETHPerClaim, "No testnet funds");
+        require(bobaToken.balanceOf(address(this)) >= bobaTokenPerClaim, "No boba token");
         if (block.timestamp >= (lastEpochStart + 1 hours)) {
             lastEpochStart = block.timestamp;
             amountClaimsInLastEpoch = 1;

--- a/boba_community/turing-twitter/hardhat.config.ts
+++ b/boba_community/turing-twitter/hardhat.config.ts
@@ -14,7 +14,6 @@ const config: HardhatUserConfig = {
     },
     boba_rinkeby: {
       url: 'https://rinkeby.boba.network',
-      bridgeCounterpartUrl: 'https://rinkeby.infura.io/v3/9aa3d95b3bc440fa88ea12eaa4456161', // public RPC
       accounts: process.env.PRIVATE_KEY !== undefined ? [process.env.PRIVATE_KEY] : [],
     } as any,
     boba_mainnet: {

--- a/boba_community/turing-twitter/scripts/reclaim.ts
+++ b/boba_community/turing-twitter/scripts/reclaim.ts
@@ -1,0 +1,40 @@
+import hre, { artifacts, ethers } from 'hardhat'
+import { ContractFactory, providers, Wallet } from 'ethers'
+// @ts-ignore
+import TuringHelperFactoryJson from './abis/TuringHelperFactory.json'
+import FaucetFactoryJson from '../artifacts/contracts/AuthenticatedFaucet.sol/AuthenticatedFaucet.json'
+import { parseEther } from 'ethers/lib/utils'
+
+const cfg = hre.network.config
+
+async function main() {
+  const local_provider = new providers.JsonRpcProvider(cfg['url'])
+  const testPrivateKey = process.env.PRIVATE_KEY_FAUCET ?? '0x___________'
+  const testWallet = new Wallet(testPrivateKey, local_provider)
+
+  const faucetFactory = new ContractFactory(
+    FaucetFactoryJson.abi,
+    FaucetFactoryJson.bytecode,
+    testWallet
+  ).attach('0x3A37a31Ee451049Db7dcc8785782A9506a59bF78')
+
+  console.log("OWNER: ", await faucetFactory.owner())
+
+  /*const helperAddr = await faucetFactory.turingHelper()
+
+  const turingFactory = new ContractFactory(
+    TuringHelperFactoryJson.abi,
+    TuringHelperFactoryJson.bytecode,
+    testWallet
+  ).attach(helperAddr)*/
+
+  const deployTx = await faucetFactory.withdraw()
+  const res = await deployTx.wait()
+
+  console.log('Withdrew at ', faucetFactory.address, deployTx, res)
+}
+
+main().catch((error) => {
+  console.error(error)
+  process.exitCode = 1
+})

--- a/boba_community/turing-twitter/test/twitter.ts
+++ b/boba_community/turing-twitter/test/twitter.ts
@@ -44,6 +44,7 @@ let L2BOBAToken: Contract;
 let addressesBOBA;
 const ethClaimAmount = ethers.utils.parseEther("0.000001")
 const bobaClaimAmount = ethers.utils.parseEther("0.1")
+const depositAmount = utils.parseEther("0.10"); // for TuringCredit!
 
 describe("Verify Twitter post for testnet funds", function() {
   before(async () => {
@@ -142,7 +143,6 @@ describe("Verify Twitter post for testnet funds", function() {
   });
 
   it("Should register and fund your Turing helper contract in turingCredit", async () => {
-    const depositAmount = utils.parseEther("0.10");
 
     const approveTx = await L2BOBAToken.approve(
       turingCredit.address,


### PR DESCRIPTION
## Overview

AuthFaucet issuance redeployment (since the PR got merged into `develop`). 
Minor clean-up + Souradeep feedback. 

## Changes

- Added boba token require in faucet
- Minor clean up
- Fixes #216

## Testing

Redeployed AuthFaucet, funded ETH + BOBA and tested via gateway. 
--> real changes have already been in `develop`. 
