### PR TITLE
ve: update to proxy compatible contracts

### DIFF
--- a/integration-tests/test/pool_dao_actions.spec.ts
+++ b/integration-tests/test/pool_dao_actions.spec.ts
@@ -110,7 +110,8 @@ describe('Dao Action Test', async () => {
       await Timelock.deployTransaction.wait()
     }
 
-    Ve = await Factory__Ve.deploy(BobaL2)
+    Ve = await Factory__Ve.deploy()
+    await Ve.initialize(BobaL2)
 
     Factory__GovernorBravoDelegate = new ContractFactory(
       GovernorBravoDelegateJson.abi,

--- a/packages/boba/ve-boba/contracts/BaseV1-dispatcher.sol
+++ b/packages/boba/ve-boba/contracts/BaseV1-dispatcher.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity 0.8.11;
 
-import "@openzeppelin/contracts/access/Ownable.sol";
+import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 
 library Math {
     function max(uint a, uint b) internal pure returns (uint) {
@@ -28,49 +28,55 @@ interface voter {
 
 // this is the layer-2 Boba custodian contract which holds and distributes emission to the voter
 
-contract BaseV1Dispatcher is Ownable {
+contract BaseV1Dispatcher is OwnableUpgradeable {
 
     uint internal constant week = 86400 * 7; // allows minting once per week (reset every Thursday 00:00 UTC)
     uint internal weeklyEmission;
-    underlying public immutable _token;
-    voter public immutable _voter;
-    ve public immutable _ve;
+    underlying public _token;
+    voter public _voter;
+    ve public _ve;
     uint public active_period;
     // update lock period according to requirements
     uint internal constant lock = 86400 * 7 * 52 * 1;
 
-    address internal initializer;
+    address internal _initializer;
 
     event Emission(address indexed sender, uint weekly);
     event WeeklyEmissionUpdated(uint priorWeeklyEmission, uint updatedWeeklyEmission);
 
-    constructor(
+    constructor() {
+    }
+
+    function initialize(
         address __voter, // the voting & distribution system
-        address  __ve // the ve system that will be locked into
-    ) {
-        initializer = msg.sender;
+        address  __ve // the ve system that will be locked into)
+    ) public initializer() {
+        _initializer = msg.sender;
         _token = underlying(ve(__ve).token());
         _voter = voter(__voter);
         _ve = ve(__ve);
         active_period = (block.timestamp + (2*week)) / week * week;
+
+        __Context_init_unchained();
+        __Ownable_init_unchained();
     }
 
     // load up the custodian contract with initAmount, which should cover for sum amounts
     // if we want initial ve dist, to be a percent owner, make sure
     // sum amounts / initAmount = % ownership of top protocols
-    function initialize(
+    function initiate_(
         address[] memory claimants,
         uint[] memory amounts,
         uint initAmount // sum amounts / initAmount = % ownership of top protocols, so if initial 20m is distributed, and target is 25% protocol ownership, then max - 4 x 20m = 80m
     ) external {
-        require(initializer == msg.sender);
+        require(_initializer == msg.sender);
         // an explicit initAmount >= sum(amounts) is not added, since if initAmount is not enough, this call would fail
         require(_token.transferFrom(msg.sender, address(this), initAmount));
         _token.approve(address(_ve), type(uint).max);
         for (uint i = 0; i < claimants.length; i++) {
             _ve.create_lock_for(amounts[i], lock, claimants[i]);
         }
-        initializer = address(0);
+        _initializer = address(0);
         active_period = (block.timestamp + week) / week * week;
     }
 
@@ -89,7 +95,7 @@ contract BaseV1Dispatcher is Ownable {
     // update period can only be called once per cycle (1 week)
     function update_period() external returns (uint) {
         uint _period = active_period;
-        if (block.timestamp >= _period + week && initializer == address(0)) { // only trigger if new week
+        if (block.timestamp >= _period + week && _initializer == address(0)) { // only trigger if new week
             _period = block.timestamp / week * week;
             active_period = _period;
             // if for an entire week, no one calls this/distribute/getReward,

--- a/packages/boba/ve-boba/contracts/ve.sol
+++ b/packages/boba/ve-boba/contracts/ve.sol
@@ -356,7 +356,7 @@ contract ve is IERC721, IERC721Metadata {
     int128 internal constant iMAXTIME = 1 * 365 * 86400;
     uint internal constant MULTIPLIER = 1 ether;
 
-    address immutable public token;
+    address public token;
     uint public supply;
     mapping(uint => LockedBalance) public locked;
 
@@ -421,11 +421,17 @@ contract ve is IERC721, IERC721Metadata {
         _entered_state = _not_entered;
     }
 
-    /// @notice Contract constructor
+    modifier onlyNotInitialized() {
+        require(address(token) == address(0), "Contract has been initialized");
+        _;
+    }
+
+    constructor() {
+    }
+
     /// @param token_addr `ERC20CRV` token address
-    constructor(
-        address token_addr
-    ) {
+    function initialize(address token_addr) public onlyNotInitialized {
+        require(token_addr != address(0), "Token cannot be zero address");
         token = token_addr;
         voter = msg.sender;
         point_history[0].blk = block.number;
@@ -1136,7 +1142,7 @@ contract ve is IERC721, IERC721Metadata {
     /// NOTE: WARNING, this method returns hypothetical balance if _t specified is prior to the lock timestamp
     /// Use with caution if this is used for determining balance at a prior timestamp
     /// To return correct values, consider using ve_for_at()
-    /// this method also uses 
+    /// this method also uses
     /// last_point.bias -= last_point.slope * int128(int256(_t) - int256(last_point.ts)); instead of
     /// last_point.bias -= last_point.slope * int128(int256(_t - last_point.ts));
     /// @notice Get the current voting power for `_tokenId`
@@ -1193,7 +1199,7 @@ contract ve is IERC721, IERC721Metadata {
 
     /// NOTE: WARNING, this method returns hypothetical balance if _t specified is prior to the lock timestamp
     /// Use with caution if this is used for determining balance at a prior timestamp
-    /// To return correct values, consider using ve_for_at() 
+    /// To return correct values, consider using ve_for_at()
     function balanceOfNFTAt(uint _tokenId, uint _t) external view returns (uint) {
         return _balanceOfNFT(_tokenId, _t);
     }

--- a/packages/boba/ve-boba/deploy/000-veBoba.ts
+++ b/packages/boba/ve-boba/deploy/000-veBoba.ts
@@ -26,8 +26,10 @@ async function main() {
     Factory__dispatcher = await ethers.getContractFactory("BaseV1Dispatcher", deployer_l2)
 
     console.log('Deploying ve...')
-    ve = await Factory__ve.deploy(l2BobaAddress)
+    ve = await Factory__ve.deploy()
     await ve.deployTransaction.wait()
+    const veInitTx = await ve.initialize(l2BobaAddress, { gasLimit: 3000000 })
+    await veInitTx.wait()
     console.log('👉 Deployed ve at ', ve.address)
 
     console.log('Deploying gauge factory...')
@@ -36,13 +38,17 @@ async function main() {
     console.log('👉 Deployed gauge factory at ', gauges.address)
 
     console.log('Deploying voter...')
-    voter = await Factory__voter.deploy(ve.address, gauges.address)
+    voter = await Factory__voter.deploy()
     await voter.deployTransaction.wait()
+    const voterInitTx = await voter.initialize(ve.address, gauges.address, { gasLimit: 3000000 })
+    await voterInitTx.wait()
     console.log('👉 Deployed voter at ', voter.address)
 
     console.log('Deploying dispatcher...')
-    dispatcher = await Factory__dispatcher.deploy(voter.address, ve.address)
+    dispatcher = await Factory__dispatcher.deploy()
     await dispatcher.deployTransaction.wait()
+    const dispatcherInitTx = await dispatcher.initialize(voter.address, ve.address, { gasLimit: 3000000 })
+    await dispatcherInitTx.wait()
     console.log('👉 Deployed dispatcher at ', dispatcher.address)
 
     console.log('Initializing contracts..')
@@ -51,14 +57,14 @@ async function main() {
     console.log('Registered Voter on Ve')
 
     // add initialize guages if any here
-    const initVoterTx = await voter.initialize([], dispatcher.address, { gasLimit: 3000000 })
+    const initVoterTx = await voter.initiate_([], dispatcher.address, { gasLimit: 3000000 })
     await initVoterTx.wait()
     console.log('Initialized Voter')
 
     // TODO: this should come from a file
     // add if there's initial ve receipients
     // approve and have boba ready on the deployer if you want to supply boba to the contract
-    const initDispatcherTx = await dispatcher.initialize([],[], 0, { gasLimit: 3000000 })
+    const initDispatcherTx = await dispatcher.initiate_([],[], 0, { gasLimit: 3000000 })
     await initDispatcherTx.wait()
     console.log('Initialized Dispatcher')
 

--- a/packages/boba/ve-boba/package.json
+++ b/packages/boba/ve-boba/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@openzeppelin/contracts": "4.3.2",
+    "@openzeppelin/contracts-upgradeable": "4.3.2",
     "dotenv": "8.2.0"
   },
   "devDependencies": {

--- a/packages/boba/ve-boba/test/2_voter.spec.ts
+++ b/packages/boba/ve-boba/test/2_voter.spec.ts
@@ -28,16 +28,18 @@ describe("voter", function () {
         await ve_underlying.deployed();
         await ve_underlying.mint(owner.address, ve_underlying_amount);
         let vecontract = await ethers.getContractFactory("contracts/ve.sol:ve");
-        ve = await vecontract.deploy(ve_underlying.address);
+        ve = await vecontract.deploy();
         await ve.deployed();
+        await ve.initialize(ve_underlying.address);
 
         const BaseV1GaugeFactory = await ethers.getContractFactory("BaseV1GaugeFactory");
         gauges_factory = await BaseV1GaugeFactory.deploy();
         await gauges_factory.deployed();
 
         const BaseV1Voter = await ethers.getContractFactory("BaseV1Voter");
-        voter = await BaseV1Voter.deploy(ve.address, gauges_factory.address);
+        voter = await BaseV1Voter.deploy();
         await voter.deployed();
+        await voter.initialize(ve.address, gauges_factory.address);
 
         await ve.setVoter(voter.address);
     });


### PR DESCRIPTION
:clipboard: https://github.com/bobanetwork/ve-boba/issues/17

## Overview

Makes ve-contracts proxy compatible

## Changes

Updates the contracts 
- to use upgradeable openzepp libraries 
- use initialize() methods 
- change original initialize() methods to initiate_()

## Testing

same tests
