### PR TITLE
fix: Lzbridge max transfer limit

### DIFF
--- a/packages/boba/contracts/contracts/lzTokenBridge/AltL1Bridge.sol
+++ b/packages/boba/contracts/contracts/lzTokenBridge/AltL1Bridge.sol
@@ -93,6 +93,7 @@ import "./lzApp/NonblockingLzApp.sol";
             require(transferredAmount <= maxTransferAmountPerDay, "max amount per day exceeded");
         } else {
             transferredAmount = _amount;
+            require(transferredAmount <= maxTransferAmountPerDay, "max amount per day exceeded");
             transferTimestampCheckPoint = block.timestamp;
         }
 

--- a/packages/boba/contracts/contracts/lzTokenBridge/EthBridge.sol
+++ b/packages/boba/contracts/contracts/lzTokenBridge/EthBridge.sol
@@ -107,6 +107,7 @@ import "./lzApp/NonblockingLzApp.sol";
             require(transferredAmount <= maxTransferAmountPerDay, "max amount per day exceeded");
         } else {
             transferredAmount = _amount;
+            require(transferredAmount <= maxTransferAmountPerDay, "max amount per day exceeded");
             transferTimestampCheckPoint = block.timestamp;
         }
 

--- a/packages/boba/contracts/test/contracts/lzTokenBridges/lzBridges.spec.ts
+++ b/packages/boba/contracts/test/contracts/lzTokenBridges/lzBridges.spec.ts
@@ -272,6 +272,23 @@ describe('LayerZero Bridges', () => {
         { value: estimatedFee._nativeFee }
       )
     ).to.be.revertedWith('max amount per day exceeded')
+
+    // move time forward to a new 24 hour epoch
+    // deposit should still fail if the amount is more than the max transfer amount per day
+    await ethers.provider.send('evm_increaseTime', [86400])
+    await ethers.provider.send('evm_mine', [])
+
+    await expect(
+      EthBridge.depositERC20(
+        L1Boba.address,
+        AltL1Boba.address,
+        depositAmount,
+        ethers.constants.AddressZero,
+        '0x', // adapterParams
+        '0x',
+        { value: estimatedFee._nativeFee }
+      )
+    ).to.be.revertedWith('max amount per day exceeded')
   })
 
   it('should be able to withdraw back to L1', async function () {
@@ -452,6 +469,24 @@ describe('LayerZero Bridges', () => {
         '0x'
       )
     const withdrawAmount = depositAmount
+    await expect(
+      AltL1Bridge.withdraw(
+        AltL1Boba.address,
+        withdrawAmount,
+        ethers.constants.AddressZero,
+        '0x', // adapterParams
+        '0x',
+        {
+          value: estimatedFeeWithdraw._nativeFee,
+        }
+      )
+    ).to.be.revertedWith('max amount per day exceeded')
+
+    // move time forward to a new 24 hour epoch
+    // withdraw should still fail if the amount is more than the max transfer amount per day
+    await ethers.provider.send('evm_increaseTime', [86400])
+    await ethers.provider.send('evm_mine', [])
+
     await expect(
       AltL1Bridge.withdraw(
         AltL1Boba.address,


### PR DESCRIPTION
:clipboard: 

## Overview

Enables the "max Transfer Amount per Day" limit for all cases

## Changes
- added the 'check' for all cases 
- did not refactor

## Testing

yarn test
