### PR TITLE
An irrelevant bit of whitespace added to a README.

### DIFF
--- a/l2geth/README.md
+++ b/l2geth/README.md
@@ -397,3 +397,4 @@ also included in our repository in the `COPYING.LESSER` file.
 The go-ethereum binaries (i.e. all code inside of the `cmd` directory) is licensed under the
 [GNU General Public License v3.0](https://www.gnu.org/licenses/gpl-3.0.en.html), also
 included in our repository in the `COPYING` file.
+


### PR DESCRIPTION
 Changes to be committed:
	modified:   l2geth/README.md
