### PR TITLE
fix: revert nft for failing mint

### DIFF
--- a/integration-tests/contracts/TestFailingMintL1StandardERC721.sol
+++ b/integration-tests/contracts/TestFailingMintL1StandardERC721.sol
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >0.7.5;
+
+import "@boba/contracts/contracts/standards/L1StandardERC721.sol";
+
+/**
+* A Failing mint L1ERC721 contract
+*/
+contract TestFailingMintL1StandardERC721 is L1StandardERC721 {
+    /**
+     * @param _l1Bridge Address of the L1 standard bridge.
+     * @param _l2Contract Address of the corresponding L2 NFT contract.
+     * @param _name ERC721 name.
+     * @param _symbol ERC721 symbol.
+     */
+    constructor(
+        address _l1Bridge,
+        address _l2Contract,
+        string memory _name,
+        string memory _symbol,
+        string memory _baseTokenURI
+    )
+        L1StandardERC721(_l1Bridge, _l2Contract, _name, _symbol, _baseTokenURI) {}
+
+    function mint(address _to, uint256 _tokenId, bytes memory _data) public virtual override onlyL1Bridge {
+        revert("mint failing");
+    }
+}

--- a/integration-tests/contracts/TestFailingMintL2StandardERC721.sol
+++ b/integration-tests/contracts/TestFailingMintL2StandardERC721.sol
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >0.7.5;
+
+import "@boba/contracts/contracts/standards/L2StandardERC721.sol";
+
+/**
+* A Failing mint L2ERC721 contract
+*/
+contract TestFailingMintL2StandardERC721 is L2StandardERC721 {
+    /**
+     * @param _l2Bridge Address of the L2 standard bridge.
+     * @param _l1Contract Address of the corresponding L1 NFT contract.
+     * @param _name ERC721 name.
+     * @param _symbol ERC721 symbol.
+     */
+    constructor(
+        address _l2Bridge,
+        address _l1Contract,
+        string memory _name,
+        string memory _symbol,
+        string memory _baseTokenURI
+    )
+        L2StandardERC721(_l2Bridge, _l1Contract, _name, _symbol, _baseTokenURI) {}
+
+    function mint(address _to, uint256 _tokenId, bytes memory _data) public virtual override onlyL2Bridge {
+        revert("mint failing");
+    }
+}

--- a/integration-tests/test/nft_bridge.spec.ts
+++ b/integration-tests/test/nft_bridge.spec.ts
@@ -2078,7 +2078,7 @@ describe('NFT Bridge Test', async () => {
       expect(l2TokenURI).to.deep.eq(l1TokenURI)
     })
 
-    it('{tag:boba} should deposit NFT back without sending data for non-native token', async () => {
+    it('should deposit NFT back without sending data for non-native token', async () => {
       const approveTX = await L1ERC721.connect(env.l1Wallet).approve(
         L1Bridge.address,
         DUMMY_TOKEN_ID

--- a/integration-tests/test/nft_bridge.spec.ts
+++ b/integration-tests/test/nft_bridge.spec.ts
@@ -1181,6 +1181,7 @@ describe('NFT Bridge Test', async () => {
       expect(ownerL1).to.deep.eq(ethers.constants.AddressZero)
       expect(ownerL2).to.deep.eq(env.l2Wallet.address)
     })
+  })
 
   describe('L1 native NFT - with Unique Data tests', async () => {
     before(async () => {

--- a/integration-tests/test/nft_bridge.spec.ts
+++ b/integration-tests/test/nft_bridge.spec.ts
@@ -1108,7 +1108,7 @@ describe('NFT Bridge Test', async () => {
       )
 
       expect(ownerL1).to.deep.eq(env.l1Wallet.address)
-    })
+    }).timeout(100000)
   })
 
   describe('L2 native NFT - failing mint on L1', async () => {
@@ -1182,7 +1182,7 @@ describe('NFT Bridge Test', async () => {
       const ownerL2 = await L2ERC721.ownerOf(DUMMY_TOKEN_ID)
 
       expect(ownerL2).to.deep.eq(env.l2Wallet.address)
-    })
+    }).timeout(100000)
   })
 
   describe('L1 native NFT - with Unique Data tests', async () => {

--- a/integration-tests/test/nft_bridge.spec.ts
+++ b/integration-tests/test/nft_bridge.spec.ts
@@ -1103,10 +1103,11 @@ describe('NFT Bridge Test', async () => {
       )
 
       const ownerL1 = await L1ERC721.ownerOf(DUMMY_TOKEN_ID)
-      const ownerL2 = await L2ERC721.ownerOf(DUMMY_TOKEN_ID)
+      await expect(L2ERC721.ownerOf(DUMMY_TOKEN_ID)).to.be.revertedWith(
+        'ERC721: owner query for nonexistent token'
+      )
 
       expect(ownerL1).to.deep.eq(env.l1Wallet.address)
-      expect(ownerL2).to.deep.eq(ethers.constants.AddressZero)
     })
   })
 
@@ -1119,8 +1120,8 @@ describe('NFT Bridge Test', async () => {
       )
 
       Factory__L1ERC721 = new ContractFactory(
-        L2ERC721FailingMintJson.abi,
-        L2ERC721FailingMintJson.bytecode,
+        L1ERC721FailingMintJson.abi,
+        L1ERC721FailingMintJson.bytecode,
         env.l1Wallet
       )
 
@@ -1175,10 +1176,11 @@ describe('NFT Bridge Test', async () => {
         L2Bridge.withdraw(L2ERC721.address, DUMMY_TOKEN_ID, 9999999)
       )
 
-      const ownerL1 = await L1ERC721.ownerOf(DUMMY_TOKEN_ID)
+      await expect(L1ERC721.ownerOf(DUMMY_TOKEN_ID)).to.be.revertedWith(
+        'ERC721: owner query for nonexistent token'
+      )
       const ownerL2 = await L2ERC721.ownerOf(DUMMY_TOKEN_ID)
 
-      expect(ownerL1).to.deep.eq(ethers.constants.AddressZero)
       expect(ownerL2).to.deep.eq(env.l2Wallet.address)
     })
   })

--- a/integration-tests/test/nft_bridge.spec.ts
+++ b/integration-tests/test/nft_bridge.spec.ts
@@ -1046,145 +1046,6 @@ describe('NFT Bridge Test', async () => {
     })
   })
 
-  describe('L1 native NFT - failing mint on L2', async () => {
-    before(async () => {
-      Factory__L1ERC721 = new ContractFactory(
-        ERC721Json.abi,
-        ERC721Json.bytecode,
-        env.l1Wallet
-      )
-
-      Factory__L2ERC721 = new ContractFactory(
-        L2ERC721FailingMintJson.abi,
-        L2ERC721FailingMintJson.bytecode,
-        env.l2Wallet
-      )
-
-      L1ERC721 = await Factory__L1ERC721.deploy('Test', 'TST')
-
-      await L1ERC721.deployTransaction.wait()
-
-      L2ERC721 = await Factory__L2ERC721.deploy(
-        L2Bridge.address,
-        L1ERC721.address,
-        'Test',
-        'TST',
-        '' // base-uri
-      )
-
-      await L2ERC721.deployTransaction.wait()
-
-      // register NFT
-      const registerL1BridgeTx = await L1Bridge.registerNFTPair(
-        L1ERC721.address,
-        L2ERC721.address,
-        'L1'
-      )
-      await registerL1BridgeTx.wait()
-
-      const registerL2BridgeTx = await L2Bridge.registerNFTPair(
-        L1ERC721.address,
-        L2ERC721.address,
-        'L1'
-      )
-      await registerL2BridgeTx.wait()
-    })
-
-    it('{tag:boba} should try deposit NFT to L2', async () => {
-      // mint nft
-      const mintTx = await L1ERC721.mint(env.l1Wallet.address, DUMMY_TOKEN_ID)
-      await mintTx.wait()
-
-      const approveTx = await L1ERC721.approve(L1Bridge.address, DUMMY_TOKEN_ID)
-      await approveTx.wait()
-
-      await env.waitForRevertXDomainTransactionL2(
-        L1Bridge.depositNFT(L1ERC721.address, DUMMY_TOKEN_ID, 9999999)
-      )
-
-      const ownerL1 = await L1ERC721.ownerOf(DUMMY_TOKEN_ID)
-      await expect(L2ERC721.ownerOf(DUMMY_TOKEN_ID)).to.be.revertedWith(
-        'ERC721: owner query for nonexistent token'
-      )
-
-      expect(ownerL1).to.deep.eq(env.l1Wallet.address)
-    }).timeout(100000)
-  })
-
-  describe('L2 native NFT - failing mint on L1', async () => {
-    before(async () => {
-      Factory__L2ERC721 = new ContractFactory(
-        ERC721Json.abi,
-        ERC721Json.bytecode,
-        env.l2Wallet
-      )
-
-      Factory__L1ERC721 = new ContractFactory(
-        L1ERC721FailingMintJson.abi,
-        L1ERC721FailingMintJson.bytecode,
-        env.l1Wallet
-      )
-
-      // deploy a L2 native NFT token each time if existing contracts are used for tests
-      L2ERC721 = await Factory__L2ERC721.deploy('Test', 'TST')
-
-      await L2ERC721.deployTransaction.wait()
-
-      L1ERC721 = await Factory__L1ERC721.deploy(
-        L1Bridge.address,
-        L2ERC721.address,
-        'Test',
-        'TST',
-        '' // base-uri
-      )
-
-      await L1ERC721.deployTransaction.wait()
-
-      // register NFT
-      const registerL1BridgeTx = await L1Bridge.registerNFTPair(
-        L1ERC721.address,
-        L2ERC721.address,
-        'L2'
-      )
-      await registerL1BridgeTx.wait()
-
-      const registerL2BridgeTx = await L2Bridge.registerNFTPair(
-        L1ERC721.address,
-        L2ERC721.address,
-        'L2'
-      )
-      await registerL2BridgeTx.wait()
-    })
-
-    it('{tag:boba} should try exit NFT from L2', async () => {
-      // mint nft
-      const mintTx = await L2ERC721.mint(env.l2Wallet.address, DUMMY_TOKEN_ID)
-      await mintTx.wait()
-
-      const approveTx = await L2ERC721.approve(L2Bridge.address, DUMMY_TOKEN_ID)
-      await approveTx.wait()
-
-      // Approve BOBA
-      const exitFee = await BOBABillingContract.exitFee()
-      const approveBOBATX = await L2BOBAToken.connect(env.l2Wallet).approve(
-        L2Bridge.address,
-        exitFee
-      )
-      await approveBOBATX.wait()
-
-      await env.waitForRevertXDomainTransactionL1(
-        L2Bridge.withdraw(L2ERC721.address, DUMMY_TOKEN_ID, 9999999)
-      )
-
-      await expect(L1ERC721.ownerOf(DUMMY_TOKEN_ID)).to.be.revertedWith(
-        'ERC721: owner query for nonexistent token'
-      )
-      const ownerL2 = await L2ERC721.ownerOf(DUMMY_TOKEN_ID)
-
-      expect(ownerL2).to.deep.eq(env.l2Wallet.address)
-    }).timeout(100000)
-  })
-
   describe('L1 native NFT - with Unique Data tests', async () => {
     before(async () => {
       Factory__L1ERC721 = new ContractFactory(
@@ -2415,6 +2276,146 @@ describe('NFT Bridge Test', async () => {
       expect(ownerL2).to.be.deep.eq(env.l2Wallet.address)
       expect(tokenURI).to.be.deep.eq(DUMMY_URI_1 + 'xyz')
     })
+  })
+
+
+  describe('L1 native NFT - failing mint on L2', async () => {
+    before(async () => {
+      Factory__L1ERC721 = new ContractFactory(
+        ERC721Json.abi,
+        ERC721Json.bytecode,
+        env.l1Wallet
+      )
+
+      Factory__L2ERC721 = new ContractFactory(
+        L2ERC721FailingMintJson.abi,
+        L2ERC721FailingMintJson.bytecode,
+        env.l2Wallet
+      )
+
+      L1ERC721 = await Factory__L1ERC721.deploy('Test', 'TST')
+
+      await L1ERC721.deployTransaction.wait()
+
+      L2ERC721 = await Factory__L2ERC721.deploy(
+        L2Bridge.address,
+        L1ERC721.address,
+        'Test',
+        'TST',
+        '' // base-uri
+      )
+
+      await L2ERC721.deployTransaction.wait()
+
+      // register NFT
+      const registerL1BridgeTx = await L1Bridge.registerNFTPair(
+        L1ERC721.address,
+        L2ERC721.address,
+        'L1'
+      )
+      await registerL1BridgeTx.wait()
+
+      const registerL2BridgeTx = await L2Bridge.registerNFTPair(
+        L1ERC721.address,
+        L2ERC721.address,
+        'L1'
+      )
+      await registerL2BridgeTx.wait()
+    })
+
+    it('{tag:boba} should try deposit NFT to L2', async () => {
+      // mint nft
+      const mintTx = await L1ERC721.mint(env.l1Wallet.address, DUMMY_TOKEN_ID)
+      await mintTx.wait()
+
+      const approveTx = await L1ERC721.approve(L1Bridge.address, DUMMY_TOKEN_ID)
+      await approveTx.wait()
+
+      await env.waitForRevertXDomainTransactionL2(
+        L1Bridge.depositNFT(L1ERC721.address, DUMMY_TOKEN_ID, 9999999)
+      )
+
+      const ownerL1 = await L1ERC721.ownerOf(DUMMY_TOKEN_ID)
+      await expect(L2ERC721.ownerOf(DUMMY_TOKEN_ID)).to.be.revertedWith(
+        'ERC721: owner query for nonexistent token'
+      )
+
+      expect(ownerL1).to.deep.eq(env.l1Wallet.address)
+    }).timeout(100000)
+  })
+
+  describe('L2 native NFT - failing mint on L1', async () => {
+    before(async () => {
+      Factory__L2ERC721 = new ContractFactory(
+        ERC721Json.abi,
+        ERC721Json.bytecode,
+        env.l2Wallet
+      )
+
+      Factory__L1ERC721 = new ContractFactory(
+        L1ERC721FailingMintJson.abi,
+        L1ERC721FailingMintJson.bytecode,
+        env.l1Wallet
+      )
+
+      // deploy a L2 native NFT token each time if existing contracts are used for tests
+      L2ERC721 = await Factory__L2ERC721.deploy('Test', 'TST')
+
+      await L2ERC721.deployTransaction.wait()
+
+      L1ERC721 = await Factory__L1ERC721.deploy(
+        L1Bridge.address,
+        L2ERC721.address,
+        'Test',
+        'TST',
+        '' // base-uri
+      )
+
+      await L1ERC721.deployTransaction.wait()
+
+      // register NFT
+      const registerL1BridgeTx = await L1Bridge.registerNFTPair(
+        L1ERC721.address,
+        L2ERC721.address,
+        'L2'
+      )
+      await registerL1BridgeTx.wait()
+
+      const registerL2BridgeTx = await L2Bridge.registerNFTPair(
+        L1ERC721.address,
+        L2ERC721.address,
+        'L2'
+      )
+      await registerL2BridgeTx.wait()
+    })
+
+    it('{tag:boba} should try exit NFT from L2', async () => {
+      // mint nft
+      const mintTx = await L2ERC721.mint(env.l2Wallet.address, DUMMY_TOKEN_ID)
+      await mintTx.wait()
+
+      const approveTx = await L2ERC721.approve(L2Bridge.address, DUMMY_TOKEN_ID)
+      await approveTx.wait()
+
+      // Approve BOBA
+      const exitFee = await BOBABillingContract.exitFee()
+      const approveBOBATX = await L2BOBAToken.connect(env.l2Wallet).approve(
+        L2Bridge.address,
+        exitFee
+      )
+      await approveBOBATX.wait()
+
+      await env.waitForRevertXDomainTransactionL1(
+        L2Bridge.withdraw(L2ERC721.address, DUMMY_TOKEN_ID, 9999999)
+      )
+
+      await expect(L1ERC721.ownerOf(DUMMY_TOKEN_ID)).to.be.revertedWith(
+        'ERC721: owner query for nonexistent token'
+      )
+      const ownerL2 = await L2ERC721.ownerOf(DUMMY_TOKEN_ID)
+
+      expect(ownerL2).to.deep.eq(env.l2Wallet.address)
+    }).timeout(100000)
   })
 
   describe('Bridges pause tests', async () => {

--- a/integration-tests/test/nft_bridge.spec.ts
+++ b/integration-tests/test/nft_bridge.spec.ts
@@ -2218,7 +2218,7 @@ describe('NFT Bridge Test', async () => {
     })
 
     it('{tag:boba} should deposit NFT back without sending data for non-native token', async () => {
-      const approveTX = await L1ERC721.connect(env.l2Wallet).approve(
+      const approveTX = await L1ERC721.connect(env.l1Wallet).approve(
         L1Bridge.address,
         DUMMY_TOKEN_ID
       )

--- a/integration-tests/test/shared/env.ts
+++ b/integration-tests/test/shared/env.ts
@@ -471,15 +471,21 @@ export class OptimismEnv {
     }
   }
 
-  // async waitForRevertXDomainTransaction(
-  //   tx: Promise<TransactionResponse> | TransactionResponse
-  // ) {
-  //   const { remoteReceipt } = await this.waitForXDomainTransaction(tx)
-  //   const [xDomainMsgHash] = await this.messenger.getMessageHashesFromL2Tx(
-  //     remoteReceipt.transactionHash
-  //   )
-  //   await this.messenger.getL1TransactionReceipt(xDomainMsgHash)
-  // }
+  async waitForRevertXDomainTransactionL2(
+    tx: Promise<TransactionResponse> | TransactionResponse
+  ) {
+    const { remoteReceipt } = await this.waitForXDomainTransaction(tx)
+    const backTx = await this.messenger.l2Provider.getTransaction(remoteReceipt.transactionHash)
+    await this.waitForXDomainTransaction(backTx)
+  }
+
+  async waitForRevertXDomainTransactionL1(
+    tx: Promise<TransactionResponse> | TransactionResponse
+  ) {
+    const { remoteReceipt } = await this.waitForXDomainTransaction(tx)
+    const backTx = await this.messenger.l1Provider.getTransaction(remoteReceipt.transactionHash)
+    await this.waitForXDomainTransaction(backTx)
+  }
 
   // async waitForRevertXDomainTransactionFast(
   //   tx: Promise<TransactionResponse> | TransactionResponse

--- a/packages/boba/contracts/contracts/bridges/L1NFTBridge.sol
+++ b/packages/boba/contracts/contracts/bridges/L1NFTBridge.sol
@@ -2,7 +2,7 @@
 // @unsupported: ovm
 
 /**
- Note: This contract has not been audited, excercise caution when using this on mainnet
+ Note: This contract has not been audited, exercise caution when using this on mainnet
  */
 pragma solidity >0.7.5;
 pragma experimental ABIEncoderV2;

--- a/packages/boba/contracts/contracts/bridges/L1NFTBridge.sol
+++ b/packages/boba/contracts/contracts/bridges/L1NFTBridge.sol
@@ -1,5 +1,9 @@
 // SPDX-License-Identifier: MIT
 // @unsupported: ovm
+
+/**
+ Note: This contract has not been audited, excercise caution when using this on mainnet
+ */
 pragma solidity >0.7.5;
 pragma experimental ABIEncoderV2;
 

--- a/packages/boba/contracts/contracts/bridges/L1NFTBridge.sol
+++ b/packages/boba/contracts/contracts/bridges/L1NFTBridge.sol
@@ -407,6 +407,8 @@ contract L1NFTBridge is iL1NFTBridge, CrossDomainEnabled, ERC721Holder, Reentran
 
             emit NFTWithdrawalFinalized(_l1Contract, _l2Contract, _from, _to, _tokenId, _data);
         } else {
+            // replyNeeded helps store the status if a message needs to be sent back to the other layer
+            bool replyNeeded = false;
             // Check the target token is compliant and
             // verify the deposited token on L2 matches the L1 deposited token representation here
             if (
@@ -416,9 +418,16 @@ contract L1NFTBridge is iL1NFTBridge, CrossDomainEnabled, ERC721Holder, Reentran
             ) {
                 // When a deposit is finalized, we credit the account on L2 with the same amount of
                 // tokens.
-                IL1StandardERC721(_l1Contract).mint(_to, _tokenId, _data);
-                emit NFTWithdrawalFinalized(_l1Contract, _l2Contract, _from, _to, _tokenId, _data);
+                try IL1StandardERC721(_l1Contract).mint(_to, _tokenId, _data) {
+                    emit NFTWithdrawalFinalized(_l1Contract, _l2Contract, _from, _to, _tokenId, _data);
+                } catch {
+                    replyNeeded = true;
+                }
             } else {
+                replyNeeded = true;
+            }
+
+            if (replyNeeded) {
                 bytes memory message = abi.encodeWithSelector(
                     iL2NFTBridge.finalizeDeposit.selector,
                     _l1Contract,

--- a/packages/boba/contracts/contracts/bridges/L2NFTBridge.sol
+++ b/packages/boba/contracts/contracts/bridges/L2NFTBridge.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 
 /**
- Note: This contract has not been audited, excercise caution when using this on mainnet
+ Note: This contract has not been audited, exercise caution when using this on mainnet
  */
 pragma solidity >0.7.5;
 pragma experimental ABIEncoderV2;

--- a/packages/boba/contracts/contracts/bridges/L2NFTBridge.sol
+++ b/packages/boba/contracts/contracts/bridges/L2NFTBridge.sol
@@ -1,4 +1,8 @@
 // SPDX-License-Identifier: MIT
+
+/**
+ Note: This contract has not been audited, excercise caution when using this on mainnet
+ */
 pragma solidity >0.7.5;
 pragma experimental ABIEncoderV2;
 

--- a/packages/boba/contracts/contracts/bridges/README.md
+++ b/packages/boba/contracts/contracts/bridges/README.md
@@ -2,6 +2,8 @@
 
 <img width="1097" alt="Boba NFT Bridge" src="https://user-images.githubusercontent.com/46272347/145503571-0b5e34c9-c55e-4ff8-8749-19a130d32958.png">
 
+> **Note: These contracts have not been audited, excercise caution when using them on mainnet**
+
 Boba NFT bridges support **native L1 NFTs** and **native L2 NFTs** to be moved back and forth.
 
 * Native L1 NFT: the original NFT contract was deployed on L1

--- a/packages/boba/contracts/contracts/bridges/README.md
+++ b/packages/boba/contracts/contracts/bridges/README.md
@@ -2,7 +2,7 @@
 
 <img width="1097" alt="Boba NFT Bridge" src="https://user-images.githubusercontent.com/46272347/145503571-0b5e34c9-c55e-4ff8-8749-19a130d32958.png">
 
-> **Note: These contracts have not been audited, excercise caution when using them on mainnet**
+> **Note: These contracts have not been audited, exercise caution when using them on mainnet**
 
 Boba NFT bridges support **native L1 NFTs** and **native L2 NFTs** to be moved back and forth.
 


### PR DESCRIPTION
:clipboard: fixes https://github.com/bobanetwork/boba/issues/405

## Overview

Allows Bridges to transfer the original NFT back to the depositor, if mint fails on the other layer.

## Changes

- updates L1NFTBridge/L2NFTBridge contracts

## Testing

yarn test:integration
