### PR TITLE
[Gateway] : Ecosystem fix unidex broken link

### DIFF
--- a/packages/boba/gateway/src/containers/ecosystem/project.list.js
+++ b/packages/boba/gateway/src/containers/ecosystem/project.list.js
@@ -150,7 +150,7 @@ export const projectList = [
   {
     "title": "Unidex",
     "canLaunch": true,
-    "link": "https://unidexbeta.app/trading",
+    "link": "https://app.unidex.exchange/trading",
     "telegram": "https://t.me/unidexfinance",
     "twitter": "https://twitter.com/UniDexFinance",
     "discord": "https://discord.com/invite/WzJPSjGj4h",


### PR DESCRIPTION
:clipboard:
Closes: https://github.com/bobanetwork/boba/issues/442

## Overview

Unidex link is broken on ecosystem page as they have migrated to new one ref issue for more details.

## Changes

Update link for the unidex app.

