### PR TITLE
remove boba turing credit predeplox for proxy

### DIFF
--- a/packages/contracts/deployments/bobaavax/README.md
+++ b/packages/contracts/deployments/bobaavax/README.md
@@ -231,21 +231,11 @@ L2_L1NativeToken
 </tr>
 <tr>
 <td>
-Lib_ResolvedDelegateBobaProxy
+Proxy__BobaTuringCredit
 </td>
 <td align="center">
 <a href="https://blockexplorer.avax.boba.network/address/0x4200000000000000000000000000000000000020">
 <code>0x4200000000000000000000000000000000000020</code>
-</a>
-</td>
-</tr>
-<tr>
-<td>
-BobaTuringCredit
-</td>
-<td align="center">
-<a href="https://blockexplorer.avax.boba.network/address/0x4200000000000000000000000000000000000021">
-<code>0x4200000000000000000000000000000000000021</code>
 </a>
 </td>
 </tr>

--- a/packages/contracts/deployments/bobabase/README.md
+++ b/packages/contracts/deployments/bobabase/README.md
@@ -241,21 +241,11 @@ L2_L1NativeToken
 </tr>
 <tr>
 <td>
-Lib_ResolvedDelegateBobaProxy
+Proxy__BobaTuringCredit
 </td>
 <td align="center">
 <a href="https://blockexplorer.bobabase.boba.network/address/0x4200000000000000000000000000000000000020">
 <code>0x4200000000000000000000000000000000000020</code>
-</a>
-</td>
-</tr>
-<tr>
-<td>
-BobaTuringCredit
-</td>
-<td align="center">
-<a href="https://blockexplorer.bobabase.boba.network/address/0x4200000000000000000000000000000000000021">
-<code>0x4200000000000000000000000000000000000021</code>
 </a>
 </td>
 </tr>

--- a/packages/contracts/deployments/bobabeam/README.md
+++ b/packages/contracts/deployments/bobabeam/README.md
@@ -231,21 +231,11 @@ L2_L1NativeToken
 </tr>
 <tr>
 <td>
-Lib_ResolvedDelegateBobaProxy
+Proxy__BobaTuringCredit
 </td>
 <td align="center">
 <a href="https://blockexplorer.bobabeam.boba.network/address/0x4200000000000000000000000000000000000020">
 <code>0x4200000000000000000000000000000000000020</code>
-</a>
-</td>
-</tr>
-<tr>
-<td>
-BobaTuringCredit
-</td>
-<td align="center">
-<a href="https://blockexplorer.bobabeam.boba.network/address/0x4200000000000000000000000000000000000021">
-<code>0x4200000000000000000000000000000000000021</code>
 </a>
 </td>
 </tr>

--- a/packages/contracts/deployments/bobabnb/README.md
+++ b/packages/contracts/deployments/bobabnb/README.md
@@ -231,21 +231,11 @@ L2_L1NativeToken
 </tr>
 <tr>
 <td>
-Lib_ResolvedDelegateBobaProxy
+Proxy__BobaTuringCredit
 </td>
 <td align="center">
 <a href="https://blockexplorer.bnb.boba.network/address/0x4200000000000000000000000000000000000020">
 <code>0x4200000000000000000000000000000000000020</code>
-</a>
-</td>
-</tr>
-<tr>
-<td>
-BobaTuringCredit
-</td>
-<td align="center">
-<a href="https://blockexplorer.bnb.boba.network/address/0x4200000000000000000000000000000000000021">
-<code>0x4200000000000000000000000000000000000021</code>
 </a>
 </td>
 </tr>

--- a/packages/contracts/deployments/bobabnbtestnet/README.md
+++ b/packages/contracts/deployments/bobabnbtestnet/README.md
@@ -241,7 +241,7 @@ L2_L1NativeToken
 </tr>
 <tr>
 <td>
-Lib_ResolvedDelegateBobaProxy
+Proxy__BobaTuringCredit
 </td>
 <td align="center">
 <a href="https://blockexplorer.testnet.bnb.boba.network/address/0x4200000000000000000000000000000000000020">
@@ -249,17 +249,6 @@ Lib_ResolvedDelegateBobaProxy
 </a>
 </td>
 </tr>
-<tr>
-<td>
-BobaTuringCredit
-</td>
-<td align="center">
-<a href="https://blockexplorer.testnet.bnb.boba.network/address/0x4200000000000000000000000000000000000021">
-<code>0x4200000000000000000000000000000000000021</code>
-</a>
-</td>
-</tr>
-<tr>
 <td>
 BobaTuringHelper
 </td>

--- a/packages/contracts/deployments/bobafuji/README.md
+++ b/packages/contracts/deployments/bobafuji/README.md
@@ -241,7 +241,7 @@ L2_L1NativeToken
 </tr>
 <tr>
 <td>
-Lib_ResolvedDelegateBobaProxy
+Proxy__BobaTuringCredit
 </td>
 <td align="center">
 <a href="https://blockexplorer.testnet.avax.boba.network/address/0x4200000000000000000000000000000000000020">
@@ -249,17 +249,6 @@ Lib_ResolvedDelegateBobaProxy
 </a>
 </td>
 </tr>
-<tr>
-<td>
-BobaTuringCredit
-</td>
-<td align="center">
-<a href="https://blockexplorer.testnet.avax.boba.network/address/0x4200000000000000000000000000000000000021">
-<code>0x4200000000000000000000000000000000000021</code>
-</a>
-</td>
-</tr>
-<tr>
 <td>
 BobaTuringHelper
 </td>

--- a/packages/contracts/deployments/bobaopera/README.md
+++ b/packages/contracts/deployments/bobaopera/README.md
@@ -231,7 +231,7 @@ L2_L1NativeToken
 </tr>
 <tr>
 <td>
-Lib_ResolvedDelegateBobaProxy
+Proxy__BobaTuringCredit
 </td>
 <td align="center">
 <a href="https://blockexplorer.bobaopera.boba.network/address/0x4200000000000000000000000000000000000020">
@@ -239,17 +239,6 @@ Lib_ResolvedDelegateBobaProxy
 </a>
 </td>
 </tr>
-<tr>
-<td>
-BobaTuringCredit
-</td>
-<td align="center">
-<a href="https://blockexplorer.bobaopera.boba.network/address/0x4200000000000000000000000000000000000021">
-<code>0x4200000000000000000000000000000000000021</code>
-</a>
-</td>
-</tr>
-<tr>
 <td>
 BobaTuringHelper
 </td>

--- a/packages/contracts/deployments/bobaoperatestnet/README.md
+++ b/packages/contracts/deployments/bobaoperatestnet/README.md
@@ -241,21 +241,11 @@ L2_L1NativeToken
 </tr>
 <tr>
 <td>
-Lib_ResolvedDelegateBobaProxy
+Proxy__BobaTuringCredit
 </td>
 <td align="center">
 <a href="https://blockexplorer.testnet.bobaopera.boba.network/address/0x4200000000000000000000000000000000000020">
 <code>0x4200000000000000000000000000000000000020</code>
-</a>
-</td>
-</tr>
-<tr>
-<td>
-BobaTuringCredit
-</td>
-<td align="center">
-<a href="https://blockexplorer.testnet.bobaopera.boba.network/address/0x4200000000000000000000000000000000000021">
-<code>0x4200000000000000000000000000000000000021</code>
 </a>
 </td>
 </tr>


### PR DESCRIPTION
Confusing naming for boba credit proxy and removed reference to predeploy 0x4200000000000000000000000000000000000020 which is the implementation of boba credit.