### PR TITLE
Fix layer zero bridge monitor

### DIFF
--- a/ops_boba/monitor/exec/run-monitor.js
+++ b/ops_boba/monitor/exec/run-monitor.js
@@ -87,11 +87,6 @@ const main = async () => {
   loop(() => blockService.startTransactionMonitor()).catch()
   loop(() => blockService.startCrossDomainMessageMonitor()).catch()
 
-  // monitor layerZero bridge:
-  const layerZeroBridgeMonitor = new LayerZeroBridgeMonitor()
-  await layerZeroBridgeMonitor.initScan()
-  await layerZeroBridgeMonitor.startMonitor()
-
   // enable the tx response time report
   if (
     process.env.SERVICE_MONITOR_ENABLE_TX_RESPONSE_TIME?.toLowerCase() ===
@@ -139,6 +134,11 @@ const main = async () => {
   ) {
     loop(() => loopTransferTx()).catch()
   }
+
+  // monitor layerZero bridge:
+  const layerZeroBridgeMonitor = new LayerZeroBridgeMonitor()
+  await layerZeroBridgeMonitor.initScan()
+  loop(() => layerZeroBridgeMonitor.startMonitor()).catch()
 }
 
 ;(async () => {

--- a/ops_boba/monitor/services/l1BridgeMonitor.js
+++ b/ops_boba/monitor/services/l1BridgeMonitor.js
@@ -323,10 +323,15 @@ class l1BridgeMonitorService extends OptimismEnv {
         resolved = await this.watcher.toCrossChainMessage(transaction)
       } catch {
         const messages = this.watcher.getMessagesByTransaction(transaction)
-        // we pick the target address is L2StandardBridge
-        resolved = messages.filter(
-          (i) => i.target === '0x4200000000000000000000000000000000000010'
-        )
+        if (typeof messages !== 'undefined') {
+          // we pick the target address is L2StandardBridge
+          resolved = messages.filter(
+            (i) => i.target === '0x4200000000000000000000000000000000000010'
+          )
+        } else {
+          // drop the message if we can't resolve it
+          continue
+        }
       }
       const latestL2Block = await this.L2Provider.getBlockNumber()
       let CDMReceipt = null

--- a/ops_boba/monitor/services/layerZeroBridge.js
+++ b/ops_boba/monitor/services/layerZeroBridge.js
@@ -98,12 +98,13 @@ class LayerZeroBridgeMonitor extends OptimismEnv {
   }
 
   async startMonitor() {
-    console.log(prefix, `start monitor`)
     this.latestBlock = await this.L1Provider.getBlockNumber()
 
     if (this.currentBlock < this.latestBlock) {
       await this.scanBlockRange(this.currentBlock, this.latestBlock)
     }
+
+    await sleep(60000)
   }
 
   async scanBlockRange(startBlock, endBlock) {


### PR DESCRIPTION
:clipboard: Add associated issues, tickets, docs URL here.

## Overview

Describe what your Pull Request is about in a few sentences.

* Add `for..loop...` for the monitor of layer zero bridge and move it to the last one, so other services don't have to wait the layer zero monitor and put the layer zero monitor in the infinity `for...loop....`.
* Add `sleep` for layer zero monitor so that it's not fired up immediately
* Skip the message if it's unsolved. Some random messages from the across bridge is unsolved.

## Changes

Describe your changes and implementation choices. More details make PRs easier to review.

- Add `for...loop..` for monitor service
- Move layer zero bridge monitor to the last one
- Add code to skip the unsolved message
- Add sleep function

## Testing

Describe how to test your new feature/bug fix and if possible, a step by step guide on how to demo this.
