### PR TITLE
Fix layer zero bridge monitor

### DIFF
--- a/ops_boba/monitor/exec/run-monitor.js
+++ b/ops_boba/monitor/exec/run-monitor.js
@@ -87,11 +87,6 @@ const main = async () => {
   loop(() => blockService.startTransactionMonitor()).catch()
   loop(() => blockService.startCrossDomainMessageMonitor()).catch()
 
-  // monitor layerZero bridge:
-  const layerZeroBridgeMonitor = new LayerZeroBridgeMonitor()
-  await layerZeroBridgeMonitor.initScan()
-  await layerZeroBridgeMonitor.startMonitor()
-
   // enable the tx response time report
   if (
     process.env.SERVICE_MONITOR_ENABLE_TX_RESPONSE_TIME?.toLowerCase() ===
@@ -139,6 +134,11 @@ const main = async () => {
   ) {
     loop(() => loopTransferTx()).catch()
   }
+
+  // monitor layerZero bridge:
+  const layerZeroBridgeMonitor = new LayerZeroBridgeMonitor()
+  await layerZeroBridgeMonitor.initScan()
+  loop(() => layerZeroBridgeMonitor.startMonitor()).catch()
 }
 
 ;(async () => {


### PR DESCRIPTION
:clipboard: Add associated issues, tickets, docs URL here.

## Overview

Describe what your Pull Request is about in a few sentences.

Add `for..loop...` for the monitor of layer zero bridge and move it to the last one, so other services don't have to wait the layer zero monitor and put the layer zero monitor in the infinity `for...loop....`.

## Changes

Describe your changes and implementation choices. More details make PRs easier to review.

- Add for...loop.. for monitor service
- Move layer zero bridge monitor to the last one

## Testing

Describe how to test your new feature/bug fix and if possible, a step by step guide on how to demo this.
