### PR TITLE
min alt l2 token fee adjustment

### DIFF
--- a/packages/contracts/contracts/L2/predeploys/Boba_GasPriceOracle.sol
+++ b/packages/contracts/contracts/L2/predeploys/Boba_GasPriceOracle.sol
@@ -89,7 +89,7 @@ contract Boba_GasPriceOracle {
     event UpdateDecimals(address, uint256);
     event WithdrawBOBA(address, address);
     event WithdrawSecondaryFeeToken(address, address);
-    event UpdateSecondaryFeeTokenMinimum(address, uint256);
+    event UpdateSecondaryFeeTokenMinimum(uint256, uint256);
 
     /**********************
      * Function Modifiers *
@@ -332,8 +332,8 @@ contract Boba_GasPriceOracle {
     function updateSecondaryFeeTokenMinimum(uint256 _secondaryFeeTokenMinimum) public onlyOwner {
         // Users should have more than 0.002 l1 native token
         require(_secondaryFeeTokenMinimum >= 2e15);
+        emit UpdateSecondaryFeeTokenMinimum(secondaryFeeTokenMinimum, _secondaryFeeTokenMinimum);
         secondaryFeeTokenMinimum = _secondaryFeeTokenMinimum;
-        emit UpdateSecondaryFeeTokenMinimum(owner(), _secondaryFeeTokenMinimum);
     }
 
     /**

--- a/packages/contracts/contracts/L2/predeploys/Boba_GasPriceOracle.sol
+++ b/packages/contracts/contracts/L2/predeploys/Boba_GasPriceOracle.sol
@@ -69,6 +69,9 @@ contract Boba_GasPriceOracle {
     // Decimals of the price ratio
     uint256 public decimals = 0;
 
+    //Minimum alt token
+    uint256 public secondaryFeeTokenMinimum = 2e15;
+
     /*************
      *  Events   *
      *************/
@@ -86,6 +89,7 @@ contract Boba_GasPriceOracle {
     event UpdateDecimals(address, uint256);
     event WithdrawBOBA(address, address);
     event WithdrawSecondaryFeeToken(address, address);
+    event UpdateSecondaryFeeTokenMinimum(address, uint256);
 
     /**********************
      * Function Modifiers *
@@ -152,6 +156,7 @@ contract Boba_GasPriceOracle {
         minPriceRatio = 500;
         marketPriceRatio = 2000;
         decimals = 0;
+        secondaryFeeTokenMinimum = 2e15;
     }
 
     /**
@@ -197,9 +202,8 @@ contract Boba_GasPriceOracle {
      */
     function useSecondaryFeeTokenAsFeeToken() public {
         require(!Address.isContract(msg.sender), "Account not EOA");
-        // Users should have more than 0.002 l1 native token
         require(
-            L2_L1NativeToken(secondaryFeeTokenAddress).balanceOf(msg.sender) >= 2e18,
+            L2_L1NativeToken(secondaryFeeTokenAddress).balanceOf(msg.sender) >= secondaryFeeTokenMinimum,
             "Insufficient secondary fee token balance"
         );
         secondaryFeeTokenUsers[msg.sender] = true;
@@ -318,6 +322,17 @@ contract Boba_GasPriceOracle {
             bytes("")
         );
         emit WithdrawSecondaryFeeToken(owner(), feeWallet);
+    }
+
+    /**
+     * Update the minimum secondary fee token minimum
+     * @param _secondaryFeeTokenMinimum the minimum amount
+     */
+    function updateSecondaryFeeTokenMinimum(uint256 _secondaryFeeTokenMinimum) public onlyOwner {
+        // Users should have more than 0.002 l1 native token
+        require(_secondaryFeeTokenMinimum >= 1e15);
+        secondaryFeeTokenMinimum = _secondaryFeeTokenMinimum;
+        emit UpdateSecondaryFeeTokenMinimum(owner(), _secondaryFeeTokenMinimum);
     }
 
     /**

--- a/packages/contracts/contracts/L2/predeploys/Boba_GasPriceOracle.sol
+++ b/packages/contracts/contracts/L2/predeploys/Boba_GasPriceOracle.sol
@@ -203,7 +203,8 @@ contract Boba_GasPriceOracle {
     function useSecondaryFeeTokenAsFeeToken() public {
         require(!Address.isContract(msg.sender), "Account not EOA");
         require(
-            L2_L1NativeToken(secondaryFeeTokenAddress).balanceOf(msg.sender) >= secondaryFeeTokenMinimum,
+            L2_L1NativeToken(secondaryFeeTokenAddress).balanceOf(msg.sender) >=
+                secondaryFeeTokenMinimum,
             "Insufficient secondary fee token balance"
         );
         secondaryFeeTokenUsers[msg.sender] = true;

--- a/packages/contracts/contracts/L2/predeploys/Boba_GasPriceOracle.sol
+++ b/packages/contracts/contracts/L2/predeploys/Boba_GasPriceOracle.sol
@@ -331,7 +331,7 @@ contract Boba_GasPriceOracle {
      */
     function updateSecondaryFeeTokenMinimum(uint256 _secondaryFeeTokenMinimum) public onlyOwner {
         // Users should have more than 0.002 l1 native token
-        require(_secondaryFeeTokenMinimum >= 1e15);
+        require(_secondaryFeeTokenMinimum >= 2e15);
         secondaryFeeTokenMinimum = _secondaryFeeTokenMinimum;
         emit UpdateSecondaryFeeTokenMinimum(owner(), _secondaryFeeTokenMinimum);
     }

--- a/packages/contracts/test/contracts/L2/predeploys/Boba_GasPriceOracle.spec.ts
+++ b/packages/contracts/test/contracts/L2/predeploys/Boba_GasPriceOracle.spec.ts
@@ -657,4 +657,52 @@ describe('Boba_GasPriceOracle', () => {
       })
     }
   })
+
+  describe('updateSecondaryFeeTokenMinimum', () => {
+    it('should revert if called by someone other than the owner', async () => {
+      await expect(
+        Boba_GasPriceOracle.connect(signer2).updateSecondaryFeeTokenMinimum(
+          utils.parseEther('0.003')
+        )
+      ).to.be.reverted
+    })
+
+    it('should revert if the new Secondary Fee Token Minimum is smaller than 0.002', async () => {
+      await expect(
+        Boba_GasPriceOracle.connect(signer1).updateSecondaryFeeTokenMinimum(
+          utils.parseEther('0.001')
+        )
+      ).to.be.reverted
+    })
+
+    it('should succeed if called by the owner', async () => {
+      await expect(
+        Boba_GasPriceOracle.connect(signer1).updateSecondaryFeeTokenMinimum(
+          utils.parseEther('0.003')
+        )
+      ).to.not.be.reverted
+    })
+
+    it('should emit event', async () => {
+      const newMin = utils.parseEther('0.006')
+      await expect(
+        Boba_GasPriceOracle.connect(signer1).updateSecondaryFeeTokenMinimum(
+          newMin
+        )
+      )
+        .to.emit(Boba_GasPriceOracle, 'UpdateSecondaryFeeTokenMinimum')
+        .withArgs(await signer1.getAddress(), newMin)
+    })
+
+    it('should emit event if Secondary Fee Token Minimum is exactly 0.002', async () => {
+      const newMin = utils.parseEther('0.002')
+      await expect(
+        Boba_GasPriceOracle.connect(signer1).updateSecondaryFeeTokenMinimum(
+          newMin
+        )
+      )
+        .to.emit(Boba_GasPriceOracle, 'UpdateSecondaryFeeTokenMinimum')
+        .withArgs(await signer1.getAddress(), newMin)
+    })
+  })
 })

--- a/packages/contracts/test/contracts/L2/predeploys/Boba_GasPriceOracle.spec.ts
+++ b/packages/contracts/test/contracts/L2/predeploys/Boba_GasPriceOracle.spec.ts
@@ -683,26 +683,28 @@ describe('Boba_GasPriceOracle', () => {
       ).to.not.be.reverted
     })
 
-    it('should emit event', async () => {
+    it.only('should emit event', async () => {
       const newMin = utils.parseEther('0.006')
+      const previousMin = await Boba_GasPriceOracle.secondaryFeeTokenMinimum()
       await expect(
         Boba_GasPriceOracle.connect(signer1).updateSecondaryFeeTokenMinimum(
           newMin
         )
       )
         .to.emit(Boba_GasPriceOracle, 'UpdateSecondaryFeeTokenMinimum')
-        .withArgs(await signer1.getAddress(), newMin)
+        .withArgs(previousMin, newMin)
     })
 
-    it('should emit event if Secondary Fee Token Minimum is exactly 0.002', async () => {
+    it.only('should emit event if Secondary Fee Token Minimum is exactly 0.002', async () => {
       const newMin = utils.parseEther('0.002')
+      const previousMin = await Boba_GasPriceOracle.secondaryFeeTokenMinimum()
       await expect(
         Boba_GasPriceOracle.connect(signer1).updateSecondaryFeeTokenMinimum(
           newMin
         )
       )
         .to.emit(Boba_GasPriceOracle, 'UpdateSecondaryFeeTokenMinimum')
-        .withArgs(await signer1.getAddress(), newMin)
+        .withArgs(previousMin, newMin)
     })
   })
 })


### PR DESCRIPTION


## Overview

Ability to update the minimum secondary fee token amount a user needs to hold.
## Changes

- add `updateSecondaryFeeTokenMinimum` method to `Boba_GasPriceOracle`
- 

## Testing

Addiing tests to `Boba_GasPriceOracle.spec.ts`