### PR TITLE
Reduce size of docker images

### DIFF
--- a/.github/workflows/ts-packages.yml
+++ b/.github/workflows/ts-packages.yml
@@ -55,7 +55,7 @@ jobs:
       - uses: codecov/codecov-action@v1
         with:
           files: ./packages/*/coverage.json, ./packages/boba/*/coverage.json
-          fail_ci_if_error: true
+          fail_ci_if_error: false
           verbose: true
           flags: coverage
 

--- a/ops/docker/Dockerfile.packages
+++ b/ops/docker/Dockerfile.packages
@@ -14,7 +14,6 @@ ADD ${SOLC_PREFIX}solc-linux-amd64-v0.6.6+commit.6c089d02  ./solc-v0.6.6+commit.
 ADD ${SOLC_PREFIX}solc-linux-amd64-v0.8.9+commit.e5eed63a  ./solc-v0.8.9+commit.e5eed63a
 ADD ${SOLC_PREFIX}solc-linux-amd64-v0.8.11+commit.d7f03943  ./solc-v0.8.11+commit.d7f03943
 
-# FROM node:16-alpine3.14 as base
 FROM node:16-buster-slim as base
 
 ARG BUILDPLATFORM
@@ -48,7 +47,6 @@ COPY packages/common-ts/package.json ./packages/common-ts/package.json
 COPY packages/contracts/package.json ./packages/contracts/package.json
 COPY packages/data-transport-layer/package.json ./packages/data-transport-layer/package.json
 COPY packages/message-relayer/package.json ./packages/message-relayer/package.json
-COPY packages/replica-healthcheck/package.json ./packages/replica-healthcheck/package.json
 COPY integration-tests/package.json ./integration-tests/package.json
 COPY ops_boba/api/package.json ./ops_boba/api/package.json
 
@@ -57,7 +55,10 @@ COPY packages/boba/gas-price-oracle/package.json ./packages/boba/gas-price-oracl
 COPY packages/boba/turing/package.json ./packages/boba/turing/package.json
 COPY packages/boba/ve-boba/package.json ./packages/boba/ve-boba/package.json
 COPY packages/boba/bobalink/package.json ./packages/boba/bobalink/package.json
+COPY packages/boba/teleportation/package.json ./packages/boba/teleportation/package.json
 
+FROM base as builder
+WORKDIR /opt/optimism
 # copy over the patches, if any...
 # needs to happen before `yarn` otherwise patch-packages does not apply the patches
 COPY ./patches ./patches
@@ -81,48 +82,85 @@ RUN chmod +x /root/.cache/hardhat-nodejs/compilers-v2/linux-amd64/*
 # build it!
 RUN yarn build
 
-FROM base as deployer
+FROM base as packages
+WORKDIR /opt/optimism
+COPY --from=builder /opt/optimism/node_modules ./node_modules
+
+COPY --from=builder /opt/optimism/packages/sdk/dist ./packages/sdk/dist
+COPY --from=builder /opt/optimism/packages/core-utils/dist ./packages/core-utils/dist
+COPY --from=builder /opt/optimism/packages/common-ts/dist ./packages/common-ts/dist
+COPY --from=builder /opt/optimism/packages/contracts/dist ./packages/contracts/dist
+COPY --from=builder /opt/optimism/packages/data-transport-layer/dist ./packages/data-transport-layer/dist
+COPY --from=builder /opt/optimism/packages/message-relayer/dist ./packages/message-relayer/dist
+
+COPY --from=builder /opt/optimism/packages/boba/contracts/dist ./packages/boba/contracts/dist
+COPY --from=builder /opt/optimism/packages/boba/gas-price-oracle/dist ./packages/boba/gas-price-oracle/dist
+COPY --from=builder /opt/optimism/packages/boba/bobalink/dist ./packages/boba/bobalink/dist
+COPY --from=builder /opt/optimism/packages/boba/teleportation/dist ./packages/boba/teleportation/dist
+
+# some packages need to access the bytecode of the contracts and deployment files
+COPY --from=builder /opt/optimism/packages/contracts ./packages/contracts
+COPY --from=builder /opt/optimism/packages/boba/turing ./packages/boba/turing
+
+FROM packages as deployer
 WORKDIR /opt/optimism/packages/contracts
 COPY ./ops/scripts/deployer.sh .
 CMD ["yarn", "run", "deploy"]
 
-FROM base as boba_deployer
+FROM packages as boba_deployer
+WORKDIR /opt/optimism/packages/boba
+COPY --from=builder /opt/optimism/packages/boba/contracts ./contracts
 WORKDIR /opt/optimism/packages/boba/contracts
 ENTRYPOINT ["./scripts/wait-for-l1-and-l2.sh", "./scripts/deployer.sh"]
 
-FROM base as data-transport-layer
+FROM packages as data-transport-layer
+WORKDIR /opt/optimism/packages
+COPY --from=builder /opt/optimism/packages/data-transport-layer ./data-transport-layer
 WORKDIR /opt/optimism/packages/data-transport-layer
 RUN mkdir ./state-dumps
 COPY ./ops/scripts/dtl.sh .
 CMD ["node", "dist/src/services/run.js"]
 
-FROM base as integration-tests
+FROM packages as integration-tests
+WORKDIR /opt/optimism/
+COPY --from=builder /opt/optimism/integration-tests ./integration-tests
+COPY --from=builder /opt/optimism/ops_boba/api ./ops_boba/api
 WORKDIR /opt/optimism/integration-tests
 COPY ./ops/scripts/integration-tests.sh ./
 CMD ["yarn", "test:integration"]
 
-FROM base as message-relayer
+FROM packages as message-relayer
+WORKDIR /opt/optimism/packages
+COPY --from=builder /opt/optimism/packages/message-relayer ./message-relayer
 WORKDIR /opt/optimism/packages/message-relayer
 COPY ./ops/scripts/relayer.sh .
 RUN chmod +x ./relayer.sh
 ENTRYPOINT ["./relayer.sh"]
 
-FROM base as boba_message-relayer-fast
+FROM packages as boba_message-relayer-fast
+WORKDIR /opt/optimism/packages
+COPY --from=builder /opt/optimism/packages/message-relayer ./message-relayer
 WORKDIR /opt/optimism/packages/message-relayer
 COPY ./ops/scripts/relayer-fast.sh .
 RUN chmod +x ./relayer-fast.sh
 ENTRYPOINT ["./relayer-fast.sh"]
 
-FROM base as gas_oracle
+FROM packages as gas_oracle
+WORKDIR /opt/optimism/packages/boba
+COPY --from=builder /opt/optimism/packages/boba/gas-price-oracle ./gas-price-oracle
 WORKDIR /opt/optimism/packages/boba/gas-price-oracle
 CMD ["npm", "run", "start"]
 
-FROM base as bobalink
+FROM packages as bobalink
+WORKDIR /opt/optimism/packages/boba
+COPY --from=builder /opt/optimism/packages/boba/bobalink ./bobalink
 WORKDIR /opt/optimism/packages/boba/bobalink
 COPY ./ops/scripts/bobalink.sh .
 RUN chmod +x ./bobalink.sh
 ENTRYPOINT ["./bobalink.sh"]
 
-FROM base as teleportation
+FROM packages as teleportation
+WORKDIR /opt/optimism/packages/boba
+COPY --from=builder /opt/optimism/packages/boba/teleportation ./teleportation
 WORKDIR /opt/optimism/packages/boba/teleportation
 CMD ["npm", "run", "start"]

--- a/ops/docker/Dockerfile.packages
+++ b/ops/docker/Dockerfile.packages
@@ -93,7 +93,6 @@ COPY --from=builder /opt/optimism/packages/contracts/dist ./packages/contracts/d
 COPY --from=builder /opt/optimism/packages/data-transport-layer/dist ./packages/data-transport-layer/dist
 COPY --from=builder /opt/optimism/packages/message-relayer/dist ./packages/message-relayer/dist
 
-COPY --from=builder /opt/optimism/packages/boba/contracts/dist ./packages/boba/contracts/dist
 COPY --from=builder /opt/optimism/packages/boba/gas-price-oracle/dist ./packages/boba/gas-price-oracle/dist
 COPY --from=builder /opt/optimism/packages/boba/bobalink/dist ./packages/boba/bobalink/dist
 COPY --from=builder /opt/optimism/packages/boba/teleportation/dist ./packages/boba/teleportation/dist

--- a/ops/docker/Dockerfile.packages
+++ b/ops/docker/Dockerfile.packages
@@ -99,6 +99,7 @@ COPY --from=builder /opt/optimism/packages/boba/teleportation/dist ./packages/bo
 
 # some packages need to access the bytecode of the contracts and deployment files
 COPY --from=builder /opt/optimism/packages/contracts ./packages/contracts
+COPY --from=builder /opt/optimism/packages/boba/contracts ./packages/boba/contracts
 COPY --from=builder /opt/optimism/packages/boba/turing ./packages/boba/turing
 
 FROM packages as deployer
@@ -107,8 +108,6 @@ COPY ./ops/scripts/deployer.sh .
 CMD ["yarn", "run", "deploy"]
 
 FROM packages as boba_deployer
-WORKDIR /opt/optimism/packages/boba
-COPY --from=builder /opt/optimism/packages/boba/contracts ./contracts
 WORKDIR /opt/optimism/packages/boba/contracts
 ENTRYPOINT ["./scripts/wait-for-l1-and-l2.sh", "./scripts/deployer.sh"]
 

--- a/ops/docker/Dockerfile.packages
+++ b/ops/docker/Dockerfile.packages
@@ -89,8 +89,6 @@ COPY --from=builder /opt/optimism/node_modules ./node_modules
 COPY --from=builder /opt/optimism/packages/sdk/dist ./packages/sdk/dist
 COPY --from=builder /opt/optimism/packages/core-utils/dist ./packages/core-utils/dist
 COPY --from=builder /opt/optimism/packages/common-ts/dist ./packages/common-ts/dist
-COPY --from=builder /opt/optimism/packages/contracts/dist ./packages/contracts/dist
-COPY --from=builder /opt/optimism/packages/data-transport-layer/dist ./packages/data-transport-layer/dist
 
 # some packages need to access the bytecode of the contracts and deployment files
 COPY --from=builder /opt/optimism/packages/contracts ./packages/contracts

--- a/ops/docker/Dockerfile.packages
+++ b/ops/docker/Dockerfile.packages
@@ -91,11 +91,6 @@ COPY --from=builder /opt/optimism/packages/core-utils/dist ./packages/core-utils
 COPY --from=builder /opt/optimism/packages/common-ts/dist ./packages/common-ts/dist
 COPY --from=builder /opt/optimism/packages/contracts/dist ./packages/contracts/dist
 COPY --from=builder /opt/optimism/packages/data-transport-layer/dist ./packages/data-transport-layer/dist
-COPY --from=builder /opt/optimism/packages/message-relayer/dist ./packages/message-relayer/dist
-
-COPY --from=builder /opt/optimism/packages/boba/gas-price-oracle/dist ./packages/boba/gas-price-oracle/dist
-COPY --from=builder /opt/optimism/packages/boba/bobalink/dist ./packages/boba/bobalink/dist
-COPY --from=builder /opt/optimism/packages/boba/teleportation/dist ./packages/boba/teleportation/dist
 
 # some packages need to access the bytecode of the contracts and deployment files
 COPY --from=builder /opt/optimism/packages/contracts ./packages/contracts


### PR DESCRIPTION
:clipboard: closed #521 

## Overview

Describe what your Pull Request is about in a few sentences.

- The sizes of images are reduced to 1.4 GB.
```
REPOSITORY                              TAG       IMAGE ID       CREATED                  SIZE
bobanetwork/bobalink                    latest    1929b9001993   Less than a second ago   1.39GB
bobanetwork/go-batch-submitter          latest    c58fb1d7305a   5 seconds ago            34.3MB
bobanetwork/integration-tests           latest    8220658a23f9   54 seconds ago           1.42GB
bobanetwork/boba_message-relayer-fast   latest    6b936ce5bfa5   56 seconds ago           1.4GB
bobanetwork/message-relayer             latest    b39389fc20f7   58 seconds ago           1.4GB
bobanetwork/boba_deployer               latest    c667f0f2a0d4   About a minute ago       1.39GB
bobanetwork/deployer                    latest    e592282b6ed4   About a minute ago       1.39GB
bobanetwork/data-transport-layer        latest    b68333c02aee   About a minute ago       1.41GB
```

- Set `fail_ci_if_error` to `false` for the codecov reprot.

## Changes

Describe your changes and implementation choices. More details make PRs easier to review.

In order to reduce the size, a new middle layer called `packages build` are introduced. The `base build` contains all `packages.json`. The `builder build` is created to install packages and build services. After that, the `dist` folders are added to `packages build`. For different services, they are built from `packages build` with its own folder.

## Testing

Describe how to test your new feature/bug fix and if possible, a step by step guide on how to demo this.

The integration tests passed.
