### PR TITLE
aws ec2 for building releases on master

### DIFF
--- a/.github/workflows/boba-publish-develop.yml
+++ b/.github/workflows/boba-publish-develop.yml
@@ -1,6 +1,7 @@
 name: Publish Packages (boba-develop)
 
 on:
+  pull_request:
   push:
     branches:
       - 'develop'
@@ -64,9 +65,44 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-yarn-
 
+      - name: Cache yarn modules
+        uses: actions/cache@v2
+        with:
+          path: '**/node_modules'
+          key: yarn-${{ hashFiles('yarn.lock') }}
+
+      - name: Cache compilers
+        uses: actions/cache@v3
+        id: cache-compilers
+        with:
+          path: |
+            /root/.cache/hardhat-nodejs/compilers-v2/
+          key: solc-compilers-${{ hashFiles('packages/**/hardhat.config.ts') }}-${{ hashFiles('packages/boba/**/hardhat.config.ts') }}
+          restore-keys: |
+            solc-compilers-${{ hashFiles('packages/**/hardhat.config.ts') }}-${{ hashFiles('packages/boba/**/hardhat.config.ts') }}
+
+      - if: ${{ steps.cache-npm.outputs.cache-hit != 'true' }}
+        name: Pull compilers
+        continue-on-error: true
+        run: |
+          mkdir -p /root/.cache/hardhat-nodejs/compilers-v2/linux-amd64/
+          cd /root/.cache/hardhat-nodejs/compilers-v2/linux-amd64/
+          find . -name list.json | grep . || curl -L https://github.com/ethereum/solc-bin/raw/gh-pages/linux-amd64/list.json -o ./list.json
+          find . -name solc-linux-amd64-v0.4.11+commit.68ef5810 | grep . || curl -L https://binaries.soliditylang.org/linux-amd64/solc-linux-amd64-v0.4.11+commit.68ef5810 -o ./solc-linux-amd64-v0.4.11+commit.68ef5810
+          find . -name solc-linux-amd64-v0.5.17+commit.d19bba13 | grep . || curl -L https://binaries.soliditylang.org/linux-amd64/solc-linux-amd64-v0.5.17+commit.d19bba13 -o ./solc-linux-amd64-v0.5.17+commit.d19bba13
+          find . -name solc-linux-amd64-v0.6.6+commit.6c089d02 | grep . || curl -L https://binaries.soliditylang.org/linux-amd64/solc-linux-amd64-v0.6.6+commit.6c089d02 -o ./solc-linux-amd64-v0.6.6+commit.6c089d02
+          find . -name solc-linux-amd64-v0.8.9+commit.e5eed63a | grep . || curl -L https://binaries.soliditylang.org/linux-amd64/solc-linux-amd64-v0.8.9+commit.e5eed63a -o ./solc-linux-amd64-v0.8.9+commit.e5eed63a
+          find . -name solc-linux-amd64-v0.8.11+commit.d7f03943 | grep . || curl -L https://binaries.soliditylang.org/linux-amd64/solc-linux-amd64-v0.8.11+commit.d7f03943 -o ./solc-linux-amd64-v0.8.11+commit.d7f03943
+          find . -name solc-linux-amd64-v0.8.15+commit.e14f2714 | grep . || curl -L https://binaries.soliditylang.org/linux-amd64/solc-linux-amd64-v0.8.15+commit.e14f2714 -o ./solc-linux-amd64-v0.8.15+commit.e14f2714
+          find . -name solc-linux-amd64-v0.8.17+commit.8df45f5f | grep . || curl -L https://binaries.soliditylang.org/linux-amd64/solc-linux-amd64-v0.8.17+commit.8df45f5f -o ./solc-linux-amd64-v0.8.11+commit.8df45f5f
+          chmod +x /root/.cache/hardhat-nodejs/compilers-v2/linux-amd64/*
+
       - name: Build the services locally
         working-directory: ./
         run: yarn && yarn build
+
+      - name: Whats in the compilers folder?
+        run: ls -altr ~/.cache/hardhat-nodejs/compilers-v2/linux-amd64/
 
       - name: Build the core services
         working-directory: ./ops

--- a/.github/workflows/boba-publish-develop.yml
+++ b/.github/workflows/boba-publish-develop.yml
@@ -1,7 +1,6 @@
 name: Publish Packages (boba-develop)
 
 on:
-  pull_request:
   push:
     branches:
       - 'develop'

--- a/.github/workflows/boba-publish-develop.yml
+++ b/.github/workflows/boba-publish-develop.yml
@@ -93,7 +93,7 @@ jobs:
           find . -name solc-linux-amd64-v0.8.9+commit.e5eed63a | grep . || curl -L https://binaries.soliditylang.org/linux-amd64/solc-linux-amd64-v0.8.9+commit.e5eed63a -o ./solc-linux-amd64-v0.8.9+commit.e5eed63a
           find . -name solc-linux-amd64-v0.8.11+commit.d7f03943 | grep . || curl -L https://binaries.soliditylang.org/linux-amd64/solc-linux-amd64-v0.8.11+commit.d7f03943 -o ./solc-linux-amd64-v0.8.11+commit.d7f03943
           find . -name solc-linux-amd64-v0.8.15+commit.e14f2714 | grep . || curl -L https://binaries.soliditylang.org/linux-amd64/solc-linux-amd64-v0.8.15+commit.e14f2714 -o ./solc-linux-amd64-v0.8.15+commit.e14f2714
-          find . -name solc-linux-amd64-v0.8.17+commit.8df45f5f | grep . || curl -L https://binaries.soliditylang.org/linux-amd64/solc-linux-amd64-v0.8.17+commit.8df45f5f -o ./solc-linux-amd64-v0.8.11+commit.8df45f5f
+          find . -name solc-linux-amd64-v0.8.17+commit.8df45f5f | grep . || curl -L https://binaries.soliditylang.org/linux-amd64/solc-linux-amd64-v0.8.17+commit.8df45f5f -o ./solc-linux-amd64-v0.8.17+commit.8df45f5f
           chmod +x /root/.cache/hardhat-nodejs/compilers-v2/linux-amd64/*
 
       - name: Build the services locally

--- a/.github/workflows/boba-publish-master.yml
+++ b/.github/workflows/boba-publish-master.yml
@@ -103,7 +103,7 @@ jobs:
           find . -name solc-linux-amd64-v0.8.9+commit.e5eed63a | grep . || curl -L https://binaries.soliditylang.org/linux-amd64/solc-linux-amd64-v0.8.9+commit.e5eed63a -o ./solc-linux-amd64-v0.8.9+commit.e5eed63a
           find . -name solc-linux-amd64-v0.8.11+commit.d7f03943 | grep . || curl -L https://binaries.soliditylang.org/linux-amd64/solc-linux-amd64-v0.8.11+commit.d7f03943 -o ./solc-linux-amd64-v0.8.11+commit.d7f03943
           find . -name solc-linux-amd64-v0.8.15+commit.e14f2714 | grep . || curl -L https://binaries.soliditylang.org/linux-amd64/solc-linux-amd64-v0.8.15+commit.e14f2714 -o ./solc-linux-amd64-v0.8.15+commit.e14f2714
-          find . -name solc-linux-amd64-v0.8.17+commit.8df45f5f | grep . || curl -L https://binaries.soliditylang.org/linux-amd64/solc-linux-amd64-v0.8.17+commit.8df45f5f -o ./solc-linux-amd64-v0.8.11+commit.8df45f5f
+          find . -name solc-linux-amd64-v0.8.17+commit.8df45f5f | grep . || curl -L https://binaries.soliditylang.org/linux-amd64/solc-linux-amd64-v0.8.17+commit.8df45f5f -o ./solc-linux-amd64-v0.8.17+commit.8df45f5f
           chmod +x /root/.cache/hardhat-nodejs/compilers-v2/linux-amd64/*
 
       - name: Build the services locally

--- a/.github/workflows/boba-publish-master.yml
+++ b/.github/workflows/boba-publish-master.yml
@@ -81,12 +81,37 @@ jobs:
           key: yarn-${{ hashFiles('yarn.lock') }}
 
       - name: Cache compilers
-        uses: actions/cache@v2
+        uses: actions/cache@v3
+        id: cache-compilers
         with:
           path: |
-            ~/.cache/buidler-nodejs/
-            ~/.cache/hardhat-nodejs/
-          key: yarn-${{ hashFiles('yarn.lock') }}
+            /root/.cache/hardhat-nodejs/compilers-v2/
+          key: solc-compilers-${{ hashFiles('packages/**/hardhat.config.ts') }}-${{ hashFiles('packages/boba/**/hardhat.config.ts') }}
+          restore-keys: |
+            solc-compilers-${{ hashFiles('packages/**/hardhat.config.ts') }}-${{ hashFiles('packages/boba/**/hardhat.config.ts') }}
+
+      - if: ${{ steps.cache-npm.outputs.cache-hit != 'true' }}
+        name: Pull compilers
+        continue-on-error: true
+        run: |
+          mkdir -p /root/.cache/hardhat-nodejs/compilers-v2/linux-amd64/
+          cd /root/.cache/hardhat-nodejs/compilers-v2/linux-amd64/
+          find . -name list.json | grep . || curl -L https://github.com/ethereum/solc-bin/raw/gh-pages/linux-amd64/list.json -o ./list.json
+          find . -name solc-linux-amd64-v0.4.11+commit.68ef5810 | grep . || curl -L https://binaries.soliditylang.org/linux-amd64/solc-linux-amd64-v0.4.11+commit.68ef5810 -o ./solc-linux-amd64-v0.4.11+commit.68ef5810
+          find . -name solc-linux-amd64-v0.5.17+commit.d19bba13 | grep . || curl -L https://binaries.soliditylang.org/linux-amd64/solc-linux-amd64-v0.5.17+commit.d19bba13 -o ./solc-linux-amd64-v0.5.17+commit.d19bba13
+          find . -name solc-linux-amd64-v0.6.6+commit.6c089d02 | grep . || curl -L https://binaries.soliditylang.org/linux-amd64/solc-linux-amd64-v0.6.6+commit.6c089d02 -o ./solc-linux-amd64-v0.6.6+commit.6c089d02
+          find . -name solc-linux-amd64-v0.8.9+commit.e5eed63a | grep . || curl -L https://binaries.soliditylang.org/linux-amd64/solc-linux-amd64-v0.8.9+commit.e5eed63a -o ./solc-linux-amd64-v0.8.9+commit.e5eed63a
+          find . -name solc-linux-amd64-v0.8.11+commit.d7f03943 | grep . || curl -L https://binaries.soliditylang.org/linux-amd64/solc-linux-amd64-v0.8.11+commit.d7f03943 -o ./solc-linux-amd64-v0.8.11+commit.d7f03943
+          find . -name solc-linux-amd64-v0.8.15+commit.e14f2714 | grep . || curl -L https://binaries.soliditylang.org/linux-amd64/solc-linux-amd64-v0.8.15+commit.e14f2714 -o ./solc-linux-amd64-v0.8.15+commit.e14f2714
+          find . -name solc-linux-amd64-v0.8.17+commit.8df45f5f | grep . || curl -L https://binaries.soliditylang.org/linux-amd64/solc-linux-amd64-v0.8.17+commit.8df45f5f -o ./solc-linux-amd64-v0.8.11+commit.8df45f5f
+          chmod +x /root/.cache/hardhat-nodejs/compilers-v2/linux-amd64/*
+
+      - name: Build the services locally
+        working-directory: ./
+        run: yarn && yarn build
+
+      - name: Whats in the compilers folder?
+        run: ls -altr ~/.cache/hardhat-nodejs/compilers-v2/linux-amd64/
 
       - name: Get the version
         id: tag
@@ -94,10 +119,6 @@ jobs:
 
       - name: Print current tag
         run: echo ${{ steps.tag.outputs.VERSION }}
-
-      - name: Build the services locally
-        working-directory: ./
-        run: yarn && yarn build
 
       - name: Build the core services
         working-directory: ./ops

--- a/.github/workflows/boba-publish-master.yml
+++ b/.github/workflows/boba-publish-master.yml
@@ -6,8 +6,41 @@ on:
     - '*'
 
 jobs:
-  build-publish-win:
+  start-runner:
+    name: Start self-hosted EC2 runner
     runs-on: ubuntu-latest
+    outputs:
+      label: ${{ steps.start-ec2-runner.outputs.label }}
+      ec2-instance-id: ${{ steps.start-ec2-runner.outputs.ec2-instance-id }}
+    # These permissions are needed to interact with GitHub's OIDC Token endpoint.
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE }}
+          aws-region: ${{ secrets.AWS_REGION }}
+      - name: Start EC2 runner
+        id: start-ec2-runner
+        uses: machulav/ec2-github-runner@v2
+        with:
+          mode: start
+          github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
+          ec2-image-id: ami-00b46fa1102c70ff2
+          ec2-instance-type: m4.4xlarge
+          subnet-id: subnet-905870ae
+          security-group-id: sg-0855631d714870b32
+          aws-resource-tags: |
+            [{
+              "Key": "Name",
+              "Value": "github-actions"
+            }]
+
+  build-publish-win:
+    needs: start-runner
+    runs-on: ${{ needs.start-runner.outputs.label }}
     # These permissions are needed to interact with GitHub's OIDC Token endpoint.
     permissions:
       id-token: write
@@ -85,3 +118,28 @@ jobs:
       #   run: |
       #        rm -rf cloudformation/deployer-rinkeby.yaml cloudformation/dummy-transaction.yaml cloudformation/omgx-monitor.yaml cloudformation/blockexplorer-blockscout.yaml cloudformation/transaction-monitor.yaml
       #        ./cfn-devenv.sh push2aws --from-tag ${{ steps.tag.outputs.VERSION }} --deploy-tag ${{ steps.tag.outputs.VERSION }}
+
+  stop-runner:
+    name: Stop self-hosted EC2 runner
+    needs:
+      - start-runner # required to get output from the start-runner job
+      - build-publish-win # required to wait when the main job is done
+    runs-on: ubuntu-latest
+    if: ${{ always() }} # required to stop the runner even if the error happened in the previous jobs
+    # These permissions are needed to interact with GitHub's OIDC Token endpoint.
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE }}
+          aws-region: ${{ secrets.AWS_REGION }}
+      - name: Stop EC2 runner
+        uses: machulav/ec2-github-runner@v2
+        with:
+          mode: stop
+          github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
+          label: ${{ needs.start-runner.outputs.label }}
+          ec2-instance-id: ${{ needs.start-runner.outputs.ec2-instance-id }}

--- a/.github/workflows/boba-publish-master.yml
+++ b/.github/workflows/boba-publish-master.yml
@@ -74,6 +74,20 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-yarn-
 
+      - name: Cache yarn modules
+        uses: actions/cache@v2
+        with:
+          path: '**/node_modules'
+          key: yarn-${{ hashFiles('yarn.lock') }}
+
+      - name: Cache compilers
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cache/buidler-nodejs/
+            ~/.cache/hardhat-nodejs/
+          key: yarn-${{ hashFiles('yarn.lock') }}
+
       - name: Get the version
         id: tag
         run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}


### PR DESCRIPTION
:clipboard: Add associated issues, tickets, docs URL here.

## Overview

Use AWS runner to build images for master tag, caching for compilers both for develop and master.

## Changes

- add start and stop runner jobs to github workflow that kick starts on master merge + tag
- reason is: operating system on raw github doesn't work well with compiling the docker containers
- This PR is to solve the following issue in circleci
```
 Caused by: Error: ENOENT: no such file or directory, stat '/home/circleci/.cache/hardhat-nodejs/compilers-v2/linux-amd64/tmp-list.json'

```
- Pre-download list.json and compilers in the machine + cache before building the whole stack
## Testing

