### PR TITLE
FIX: MinTokenFee check updated on gateway for BNB and other tokens.

### DIFF
--- a/packages/boba/gateway/src/components/mainMenu/feeSwitcher/FeeSwitcher.js
+++ b/packages/boba/gateway/src/components/mainMenu/feeSwitcher/FeeSwitcher.js
@@ -82,7 +82,7 @@ function FeeSwitcher() {
       tooSmallL1NativeToken = true
     } else {
       //check actual balance
-      tooSmallL1NativeToken = new BN(logAmount(balanceL1NativeToken.balance, 18)).lt(new BN(0.5))
+      tooSmallL1NativeToken = new BN(logAmount(balanceL1NativeToken.balance, 18)).lt(new BN(0.002))
     }
 
     if (!balanceBOBA && !balanceL1NativeToken) {


### PR DESCRIPTION
:clipboard: Add associated issues, tickets, docs URL here.
closes: https://github.com/bobanetwork/boba/issues/536
## Overview

Min balance required to use the native token as a fee set to 0.05, which is too high in the case of BNB

## Changes

As per the [GasPriceOrcle contract](https://github.com/bobanetwork/boba/blob/alt-l1/packages/contracts/contracts/L2/predeploys/Boba_GasPriceOracle.sol#L73) it seems min required balance is only 0.002

- Updated the checks for the required balance for a native token to 0.002
