### PR TITLE
rename AA contract registrations on AM

### DIFF
--- a/packages/boba/account-abstraction/deploy/1-deploy-helper.ts
+++ b/packages/boba/account-abstraction/deploy/1-deploy-helper.ts
@@ -92,7 +92,7 @@ const deployFn: DeployFunction = async (hre) => {
   }
   await hre.deployments.save('BundlerHelper', BundlerHelperDeploymentSubmission)
 
-  await registerBobaAddress((hre as any).deployConfig.addressManager, 'Boba_BundlerHelper', BundlerHelperAddress )
+  await registerBobaAddress((hre as any).deployConfig.addressManager, 'L2_Boba_BundlerHelper', BundlerHelperAddress )
 }
 
 export default deployFn

--- a/packages/boba/account-abstraction/deploy/2-deploy_entrypoint.ts
+++ b/packages/boba/account-abstraction/deploy/2-deploy_entrypoint.ts
@@ -22,7 +22,7 @@ const deployFn: DeployFunction = async (hre) => {
     abi: EntryPointJson.abi
   }
   await hre.deployments.save('EntryPoint', EntryPointDeploymentSubmission)
-  await registerBobaAddress( (hre as any).deployConfig.addressManager, 'Boba_EntryPoint', EntryPointAddress )
+  await registerBobaAddress( (hre as any).deployConfig.addressManager, 'L2_Boba_EntryPoint', EntryPointAddress )
 }
 
 export default deployFn

--- a/packages/boba/account-abstraction/deploy/3-deploy-deposit-paymaster.ts
+++ b/packages/boba/account-abstraction/deploy/3-deploy-deposit-paymaster.ts
@@ -17,7 +17,7 @@ const deployFn: DeployFunction = async (hre) => {
   console.log(`EntryPoint is located at: ${entryPoint.address}`)
   const ethPriceOracle = await (hre as any).deployConfig.addressManager.getAddress('FeedRegistry')
   console.log(`Eth Price Oracle is located at: ${ethPriceOracle}`)
-  const entryPointFromAM = await (hre as any).deployConfig.addressManager.getAddress('Boba_EntryPoint')
+  const entryPointFromAM = await (hre as any).deployConfig.addressManager.getAddress('L2_Boba_EntryPoint')
   if (entryPoint.address.toLowerCase() === entryPointFromAM.toLowerCase()) {
     const bobaDepositPaymasterConstructorArgs = ethers.utils.defaultAbiCoder.encode(
       ["address", "address"],
@@ -38,7 +38,7 @@ const deployFn: DeployFunction = async (hre) => {
     }
     await hre.deployments.save('BobaDepositPaymaster', BobaDepositPaymasterDeploymentSubmission)
 
-    await registerBobaAddress( (hre as any).deployConfig.addressManager, 'BobaDepositPaymaster', BobaDepositPaymasterAddress )
+    await registerBobaAddress( (hre as any).deployConfig.addressManager, 'L2_BobaDepositPaymaster', BobaDepositPaymasterAddress )
   }
 }
 

--- a/packages/boba/account-abstraction/deploy/4-deploy-verifying-paymaster.ts
+++ b/packages/boba/account-abstraction/deploy/4-deploy-verifying-paymaster.ts
@@ -23,7 +23,7 @@ const deployFn: DeployFunction = async (hre) => {
   console.log(`BobaDepositPaymaster is located at: ${bobaDepositPaymaster.address}`)
   const bobaToken = await (hre as any).deployConfig.addressManager.getAddress('TK_L2BOBA')
   console.log(`Boba is located at: ${bobaToken}`)
-  const entryPointFromAM = await (hre as any).deployConfig.addressManager.getAddress('Boba_EntryPoint')
+  const entryPointFromAM = await (hre as any).deployConfig.addressManager.getAddress('L2_Boba_EntryPoint')
   if (entryPoint.address.toLowerCase() === entryPointFromAM.toLowerCase()) {
     const bobaVerifyingPaymasterConstructorArgs = ethers.utils.defaultAbiCoder.encode(
       ["address", "address","address", "address"],
@@ -43,7 +43,7 @@ const deployFn: DeployFunction = async (hre) => {
     }
     await hre.deployments.save('BobaVerifyingPaymaster', BobaVerifyingPaymasterDeploymentSubmission)
 
-    await registerBobaAddress( (hre as any).deployConfig.addressManager, 'BobaVerifyingPaymaster', BobaVerifyingPaymasterAddress )
+    await registerBobaAddress( (hre as any).deployConfig.addressManager, 'L2_BobaVerifyingPaymaster', BobaVerifyingPaymasterAddress )
   }
 }
 

--- a/packages/boba/account-abstraction/deploy/5-dump-addresses.ts
+++ b/packages/boba/account-abstraction/deploy/5-dump-addresses.ts
@@ -10,9 +10,9 @@ const deployFn: DeployFunction = async (hre) => {
   for (const key in deployments) {
     if (deployments.hasOwnProperty(key)) {
         if (key == 'EntryPoint' || key == 'BundlerHelper') {
-          contracts['BOBA_'+key] = deployments[key].address
+          contracts['L2_BOBA_'+key] = deployments[key].address
         } else {
-          contracts[key] = deployments[key].address
+          contracts['L2_'+key] = deployments[key].address
         }
     }
   }


### PR DESCRIPTION
:clipboard:

## Overview

Rename address manager registrations for AA contracts.

## Changes

- registration names (BobaEntryPoint, BobaBundlerHelper, BobaDepositPaymaster, BobaVerifyingPaymaster) changed from "X" to "L2_X"

## Testing

/
