### PR TITLE
Bundler SDK - NPM release pipeline

### DIFF
--- a/.github/workflows/aa-bundler-sdk.yml
+++ b/.github/workflows/aa-bundler-sdk.yml
@@ -1,0 +1,23 @@
+name: Publish AA-Bundler to NPM
+on:
+  release:
+    types: [created]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: '16.x'
+          registry-url: 'https://registry.npmjs.org'
+      - name: Install dependencies and build 🔧
+        run: yarn install --frozen-lockfile --legacy-peer-deps && yarn run build
+      - name: Publish package on NPM 📦
+        working-directory: ./packages/boba/bundler_sdk
+        run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_BOBA_FOUNDATION }}


### PR DESCRIPTION
## Overview

Add CI/CD pipeline for `@bobanetwork/bundler_sdk`. 

resolves #[739](https://github.com/bobanetwork/boba/issues/739)

## Changes

- Rename bundler_sdk scope from `@boba` to `@bobanetwork` as the scope on npmjs is unfortunately already taken & refactored usages (but didn't do so for other packages yet - TBD)
- NPM package released once we create a new release automatically

## Testing

Test run of pipeline successful. Test package has been deleted from the registry. 
