### PR TITLE
Fix gateway links - resolve #766

### DIFF
--- a/boba_documentation/developer/bridge-l1-and-l2/boba-token-bridge.md
+++ b/boba_documentation/developer/bridge-l1-and-l2/boba-token-bridge.md
@@ -91,7 +91,7 @@ Example code can be found here: [bridgeFromEthereumToAltL.js](https://github.com
 
 <figure><img src="../../../.gitbook/assets/Artboard 2 (19).png" alt=""><figcaption></figcaption></figure>
 
-For normal users, you can go to [Alt L1 Gateway](https:/gateway.\[CHAIN\_NAME].boba.network) first, then head to [wallet](https:/gateway.\[CHAIN\_NAME].boba.network/wallet/) page. After connecting to it on Alt L1, you can click the `Bridge To Ethereum` button to bridge your BOBA tokens from Alt L1 to Ethereum.
+For normal users, you can go to [Alt L1 Gateway](https://gateway.boba.network) first, then head to [wallet](https://gateway.boba.network/wallet/) page. After connecting to it on Alt L1, you can click the `Bridge To Ethereum` button to bridge your BOBA tokens from Alt L1 to Ethereum.
 
 For developers, you can interact with [`AltL1Bridge` (opens new window)](https://github.com/bobanetwork/boba/blob/develop/packages/boba/contracts/contracts/lzTokenBridge/AltL1Bridge.sol) to deposit BOBA tokens from Alt L1 to Ethereum.
 

--- a/boba_documentation/developer/developer-start.md
+++ b/boba_documentation/developer/developer-start.md
@@ -23,7 +23,7 @@ Welcome to Boba. Boba is a compute-focused L2. We believe that L2s can play a un
 
 For most contracts, the deploy experience is exactly like deploying on Ethereum. You will need to have some ETH (or Goerli ETH) on Boba and you will have to change your RPC endpoint to either `https://mainnet.boba.network` or `https://goerli.boba.network`. That's it!
 
-The [Mainnet blockexplorer](https://bobascan.com) and the [Goerli blockexplorer](https://testnet.bobascan.com) are similar to Etherscan. The [Mainnet gateway](https://gateway.boba.network) and the [Goerli gateway](https://gateway.goerli.boba.network) allow you to see your balances and bridge funds, among many other functions.
+The [Mainnet blockexplorer](https://bobascan.com) and the [Goerli blockexplorer](https://testnet.bobascan.com) are similar to Etherscan. The [Gateway](https://gateway.boba.network) allows you to see your balances and bridge funds, among many other functions.
 
 
 

--- a/boba_documentation/developer/faucets.md
+++ b/boba_documentation/developer/faucets.md
@@ -6,7 +6,7 @@ description: Faucets
 
 <figure><img src="../../.gitbook/assets/Artboard 1 (15) (1).png" alt=""><figcaption></figcaption></figure>
 
-If you do not have Goerli ETH, you can get some from [Goerli Authenticated Faucet](https://faucetlink.to/goerli). For Goerli BOBA, use the [BOBA faucet](https://gateway.goerli.boba.network/wallet).
+If you do not have Goerli ETH, you can get some from [Goerli Authenticated Faucet](https://faucetlink.to/goerli). For Goerli BOBA, use the [BOBA faucet](https://gateway.boba.network/wallet).
 
 
 

--- a/boba_documentation/developer/faucets.md
+++ b/boba_documentation/developer/faucets.md
@@ -12,22 +12,22 @@ If you do not have Goerli ETH, you can get some from [Goerli Authenticated Fauce
 
 <figure><img src="../../.gitbook/assets/Artboard 2 (9).png" alt=""><figcaption></figcaption></figure>
 
-If you do not have Fuji Avax, you can get some from [Fuji Faucet](https://faucet.avax.network). For Fuji BOBA, use the [BOBA faucet](https://gateway.testnet.avax.boba.network/wallet).
+If you do not have Fuji Avax, you can get some from [Fuji Faucet](https://faucet.avax.network). For Fuji BOBA, use the [BOBA faucet](https://gateway.boba.network/wallet).
 
 
 
 <figure><img src="../../.gitbook/assets/Artboard 3 (7).png" alt=""><figcaption></figcaption></figure>
 
-If you do not have Opera FTM, you can get some from [FTM Faucet](https://faucet.fantom.network/). For Opera BOBA, use the [BOBA faucet](https://gateway.testnet.bobaopera.boba.network/wallet).
+If you do not have Opera FTM, you can get some from [FTM Faucet](https://faucet.fantom.network/). For Opera BOBA, use the [BOBA faucet](https://gateway.boba.network/wallet).
 
 
 
 <figure><img src="../../.gitbook/assets/Artboard 4 (1).png" alt=""><figcaption></figcaption></figure>
 
-If you do not have testnet BNB, you can get some from [BNB Faucet](https://testnet.binance.org/faucet-smart). For testnet BOBA, use the [BOBA faucet](https://gateway.testnet.bnb.boba.network/wallet).
+If you do not have testnet BNB, you can get some from [BNB Faucet](https://testnet.binance.org/faucet-smart). For testnet BOBA, use the [BOBA faucet](https://gateway.boba.network/wallet).
 
 
 
 <figure><img src="../../.gitbook/assets/Artboard 5 (7).png" alt=""><figcaption></figcaption></figure>
 
-If you do not have testnet DEV tokens, you can get some from [DEV Faucet](https://apps.moonbeam.network/moonbase-alpha/faucet/). For testnet BOBA, use the [BOBA faucet](https://gateway.bobabase.boba.network/wallet).
+If you do not have testnet DEV tokens, you can get some from [DEV Faucet](https://apps.moonbeam.network/moonbase-alpha/faucet/). For testnet BOBA, use the [BOBA faucet](https://gateway.boba.network/wallet).

--- a/boba_documentation/developer/network-avalanche.md
+++ b/boba_documentation/developer/network-avalanche.md
@@ -21,7 +21,7 @@ description: A collection of links and addresses to get started on Boba-Avalanch
 
 ### Testnet Fountain for Developers on Boba Avalanche Testnet L2
 
-There is a Boba Avalanche testnet [fountain](https://gateway.testnet.avax.boba.network) for `BOBA`. Authentication is via Twitter - please go to the gateway and connect your MetaMask wallet to the Boba Avalanche Testnet L2. In **gateway > wallet**, you will see the `Developer Twitter/Turing test token fountain`. This system uses Turing hybrid compute to interact with Twitter.
+There is a Boba Avalanche testnet [fountain](https://gateway.boba.network) for `BOBA`. Authentication is via Twitter - please go to the gateway and connect your MetaMask wallet to the Boba Avalanche Testnet L2. In **gateway > wallet**, you will see the `Developer Twitter/Turing test token fountain`. This system uses Turing hybrid compute to interact with Twitter.
 
 ### Bridging
 
@@ -56,15 +56,15 @@ For **secondary addresses**, such as L2 Tokens and Messengers, please see the [B
 
 ### Boba Avalanche Testnet Links and Endpoints
 
-|               |                                                                                                    |
-| ------------- | -------------------------------------------------------------------------------------------------- |
-| ChainID       | 4328                                                                                               |
-| RPC           | [https://testnet.avax.boba.network](https://testnet.avax.boba.network)                             |
-| Replica RPC   | [https://replica.testnet.avax.boba.network](https://replica.testnet.avax.boba.network)             |
-| Gateway       | [https://gateway.testnet.avax.boba.network](https://gateway.testnet.avax.boba.network)             |
+|               |                                                                                  |
+| ------------- | -------------------------------------------------------------------------------- |
+| ChainID       | 4328                                                                             |
+| RPC           | [https://testnet.avax.boba.network](https://testnet.avax.boba.network)           |
+| Replica RPC   | [https://replica.testnet.avax.boba.network](https://replica.testnet.avax.boba.network) |
+| Gateway       | [https://gateway.boba.network](https://gateway.boba.network)             |
 | Blockexplorer | [https://blockexplorer.testnet.avax.boba.network](https://blockexplorer.testnet.avax.boba.network) |
-| Websocket     | [wss://wss.testnet.avax.boba.network](wss://wss.testnet.avax.boba.network)                         |
-| Gas Cap       | 50000000                                                                                           |
+| Websocket     | [wss://wss.testnet.avax.boba.network](wss://wss.testnet.avax.boba.network)       |
+| Gas Cap       | 50000000                                                                         |
 
 
 
@@ -97,12 +97,12 @@ For **secondary addresses**, such as L2 Tokens and Messengers, please see the [B
 
 ### Boba Avalanche Links and Endpoints
 
-|               |                                                                                    |
-| ------------- | ---------------------------------------------------------------------------------- |
-| ChainID       | 43288                                                                              |
-| RPC Read      | [https://avax.boba.network](https://avax.boba.network)                             |
-| Write RPC     | [https://replica.avax.boba.network](https://replica.avax.boba.network)             |
-| Gateway       | [https://gateway.avax.boba.network](https://gateway.avax.boba.network)             |
+|               |                                                                                  |
+| ------------- | -------------------------------------------------------------------------------- |
+| ChainID       | 43288                                                                            |
+| RPC Read      | [https://avax.boba.network](https://avax.boba.network)                           |
+| Write RPC     | [https://replica.avax.boba.network](https://replica.avax.boba.network)           |
+| Gateway       | [https://gateway.boba.network](https://gateway.boba.network)             |
 | Blockexplorer | [https://blockexplorer.avax.boba.network](https://blockexplorer.avax.boba.network) |
-| Websocket     | [wss://wss.avax.boba.network](wss://wss.avax.boba.network)                         |
-| Gas Cap       | 50000000                                                                           |
+| Websocket     | [wss://wss.avax.boba.network](wss://wss.avax.boba.network)                       |
+| Gas Cap       | 50000000                                                                         |

--- a/boba_documentation/developer/network-bnb.md
+++ b/boba_documentation/developer/network-bnb.md
@@ -21,7 +21,7 @@ description: A collection of links and addresses to get started on Boba-BNB
 
 ### Testnet Fountain for Developers on BNB Testnet L2
 
-There is a Boba BNB testnet [fountain](https://gateway.testnet.bnb.boba.network) for `BOBA`. Authentication is via Twitter - please go to the gateway and connect your MetaMask wallet to the Boba BNB testnet L2. In **gateway > wallet**, you will see the `Developer Twitter/Turing test token fountain`. This system uses Turing hybrid compute to interact with Twitter.
+There is a Boba BNB testnet [fountain](https://gateway.boba.network) for `BOBA`. Authentication is via Twitter - please go to the gateway and connect your MetaMask wallet to the Boba BNB testnet L2. In **gateway > wallet**, you will see the `Developer Twitter/Turing test token fountain`. This system uses Turing hybrid compute to interact with Twitter.
 
 ### Bridging
 
@@ -56,15 +56,15 @@ For **secondary addresses**, such as L2 Tokens and Messengers, please see the [B
 
 ### Boba BNB Testnet Links and Endpoints
 
-|               |                                                                                                  |
-| ------------- | ------------------------------------------------------------------------------------------------ |
-| ChainID       | 9728                                                                                             |
-| RPC           | [https://testnet.bnb.boba.network](https://testnet.bnb.boba.network)                             |
-| Replica RPC   | [https://replica.testnet.bnb.boba.network](https://replica.testnet.bnb.boba.network)             |
-| Gateway       | [https://gateway.testnet.bnb.boba.network](https://gateway.testnet.bnb.boba.network)             |
+|               |                                                                                         |
+| ------------- | --------------------------------------------------------------------------------------- |
+| ChainID       | 9728                                                                                    |
+| RPC           | [https://testnet.bnb.boba.network](https://testnet.bnb.boba.network)                    |
+| Replica RPC   | [https://replica.testnet.bnb.boba.network](https://replica.testnet.bnb.boba.network)    |
+| Gateway       | [https://gateway.boba.network](https://gateway.boba.network)             |
 | Blockexplorer | [https://blockexplorer.testnet.bnb.boba.network](https://blockexplorer.testnet.bnb.boba.network) |
-| Websocket     | [wss://wss.testnet.bnb.boba.network](wss://wss.testnet.bnb.boba.network)                         |
-| Gas Cap       | 50000000                                                                                         |
+| Websocket     | [wss://wss.testnet.bnb.boba.network](wss://wss.testnet.bnb.boba.network)                |
+| Gas Cap       | 50000000                                                                                |
 
 
 
@@ -97,12 +97,12 @@ For **secondary addresses**, such as L2 Tokens and Messengers, please see the [B
 
 ### Boba BNB Links and Endpoints (tbd)
 
-|               |                                                                                  |
-| ------------- | -------------------------------------------------------------------------------- |
-| ChainID       | 56288                                                                            |
-| RPC           | [https://bnb.boba.network](https://bnb.boba.network)                             |
-| Replica RPC   | [https://replica.bnb.boba.network](https://replica.bnb.boba.network)             |
-| Gateway       | [https://gateway.bnb.boba.network](https://gateway.bnb.boba.network)             |
+|               |                                                                                |
+| ------------- | ------------------------------------------------------------------------------ |
+| ChainID       | 56288                                                                          |
+| RPC           | [https://bnb.boba.network](https://bnb.boba.network)                           |
+| Replica RPC   | [https://replica.bnb.boba.network](https://replica.bnb.boba.network)           |
+| Gateway       | [https://gateway.boba.network](https://gateway.boba.network)             |
 | Blockexplorer | [https://blockexplorer.bnb.boba.network](https://blockexplorer.bnb.boba.network) |
-| Websocket     | [wss://wss.bnb.boba.network](wss://wss.bnb.boba.network)                         |
-| Gas Cap       | 50000000                                                                         |
+| Websocket     | [wss://wss.bnb.boba.network](wss://wss.bnb.boba.network)                       |
+| Gas Cap       | 50000000                                                                       |

--- a/boba_documentation/developer/network-fantom.md
+++ b/boba_documentation/developer/network-fantom.md
@@ -21,7 +21,7 @@ description: A collection of links and addresses to get started on Boba-Fantom
 
 ### Testnet Fountain for Developers on Bobaopera Testnet L2
 
-There is a Bobaopera testnet [fountain](https://gateway.testnet.bobaopera.boba.network) for `BOBA`. Authentication is via Twitter - please go to the gateway and connect your MetaMask wallet to the Bobaopera Testnet L2. In **gateway > wallet**, you will see the `Developer Twitter/Turing test token fountain`. This system uses Turing hybrid compute to interact with Twitter.
+There is a Bobaopera testnet [fountain](https://gateway.boba.network) for `BOBA`. Authentication is via Twitter - please go to the gateway and connect your MetaMask wallet to the Bobaopera Testnet L2. In **gateway > wallet**, you will see the `Developer Twitter/Turing test token fountain`. This system uses Turing hybrid compute to interact with Twitter.
 
 ### Bridging
 
@@ -56,15 +56,15 @@ For **secondary addresses**, such as L2 Tokens and Messengers, please see the [B
 
 ### Bobaopera Testnet Links and Endpoints
 
-|               |                                                                                                              |
-| ------------- | ------------------------------------------------------------------------------------------------------------ |
-| ChainID       | 4051                                                                                                         |
-| RPC           | [https://testnet.bobaopera.boba.network](https://testnet.bobaopera.boba.network)                             |
-| Replica RPC   | [https://replica.testnet.bobaopera.boba.network](https://replica.testnet.bobaopera.boba.network)             |
-| Gateway       | [https://gateway.testnet.bobaopera.boba.network](https://gateway.testnet.bobaopera.boba.network)             |
+|               |                                                                                            |
+| ------------- | ------------------------------------------------------------------------------------------ |
+| ChainID       | 4051                                                                                       |
+| RPC           | [https://testnet.bobaopera.boba.network](https://testnet.bobaopera.boba.network)           |
+| Replica RPC   | [https://replica.testnet.bobaopera.boba.network](https://replica.testnet.bobaopera.boba.network) |
+| Gateway       | [https://gateway.boba.network](https://gateway.boba.network)             |
 | Blockexplorer | [https://blockexplorer.testnet.bobaopera.boba.network](https://blockexplorer.testnet.bobaopera.boba.network) |
-| Websocket     | [wss://wss.testnet.bobaopera.boba.network](wss://wss.testnet.bobaopera.boba.network)                         |
-| Gas Cap       | 50000000                                                                                                     |
+| Websocket     | [wss://wss.testnet.bobaopera.boba.network](wss://wss.testnet.bobaopera.boba.network)       |
+| Gas Cap       | 50000000                                                                                   |
 
 
 
@@ -97,12 +97,12 @@ For **secondary addresses**, such as L2 Tokens and Messengers, please see the [B
 
 ### Bobaopera Links and Endpoints (tbd)
 
-|               |                                                                                              |
-| ------------- | -------------------------------------------------------------------------------------------- |
-| ChainID       | 301                                                                                          |
-| RPC           | [https://bobaopera.boba.network](https://bobaopera.boba.network)                             |
-| Replica RPC   | [https://replica.bobaopera.boba.network](https://replica.bobaopera.boba.network)             |
-| Gateway       | [https://gateway.bobaopera.boba.network](https://gateway.bobaopera.boba.network)             |
+|               |                                                                                            |
+| ------------- | ------------------------------------------------------------------------------------------ |
+| ChainID       | 301                                                                                        |
+| RPC           | [https://bobaopera.boba.network](https://bobaopera.boba.network)                           |
+| Replica RPC   | [https://replica.bobaopera.boba.network](https://replica.bobaopera.boba.network)           |
+| Gateway       | [https://gateway.boba.network](https://gateway.boba.network)             |
 | Blockexplorer | [https://blockexplorer.bobaopera.boba.network](https://blockexplorer.bobaopera.boba.network) |
-| Websocket     | [wss://wss.bobaopera.boba.network](wss://wss.bobaopera.boba.network)                         |
-| Gas Cap       | 50000000                                                                                     |
+| Websocket     | [wss://wss.bobaopera.boba.network](wss://wss.bobaopera.boba.network)                       |
+| Gas Cap       | 50000000                                                                                   |

--- a/boba_documentation/developer/network-moonbeam.md
+++ b/boba_documentation/developer/network-moonbeam.md
@@ -56,16 +56,16 @@ For **secondary addresses**, such as L2 Tokens and Messengers, please see the [B
 
 ### Bobabase Links and Endpoints
 
-|                   |                                                                                            |
-| ----------------- | ------------------------------------------------------------------------------------------ |
-| ChainID           | 1297                                                                                       |
-| RPC               | [https://bobabase.boba.network](https://bobabase.boba.network)                             |
-| Replica RPC       | [https://replica.bobabase.boba.network](https://replica.bobabase.boba.network)             |
-| Gateway           | [https://gateway.bobabase.boba.network](https://gateway.bobabase.boba.network)             |
+|                   |                                                                                          |
+| ----------------- | ---------------------------------------------------------------------------------------- |
+| ChainID           | 1297                                                                                     |
+| RPC               | [https://bobabase.boba.network](https://bobabase.boba.network)                           |
+| Replica RPC       | [https://replica.bobabase.boba.network](https://replica.bobabase.boba.network)           |
+| Gateway           | [https://gateway.boba.network](https://gateway.boba.network)             |
 | Blockexplorer     | [https://blockexplorer.bobabase.boba.network](https://blockexplorer.bobabase.boba.network) |
-| Websocket         | [wss://wss.bobabase.boba.network](wss://wss.bobabase.boba.network)                         |
-| Replica Websocket | [wss://replica-wss.bobabeam.boba.network](wss://replica-wss.bobabeam.boba.network)         |
-| Gas Cap           | 50000000                                                                                   |
+| Websocket         | [wss://wss.bobabase.boba.network](wss://wss.bobabase.boba.network)                       |
+| Replica Websocket | [wss://replica-wss.bobabeam.boba.network](wss://replica-wss.bobabeam.boba.network)       |
+| Gas Cap           | 50000000                                                                                 |
 
 
 
@@ -98,13 +98,13 @@ For **secondary addresses**, such as L2 Tokens and Messengers, please see the [B
 
 ### Bobabeam Links and Endpoints
 
-|                   |                                                                                            |
-| ----------------- | ------------------------------------------------------------------------------------------ |
-| ChainID           | 1294                                                                                       |
-| RPC               | [https://bobabeam.boba.network](https://bobabeam.boba.network)                             |
-| Replica RPC       | [https://replica.bobabeam.boba.network](https://replica.bobabeam.boba.network)             |
-| Gateway           | [https://gateway.bobabeam.boba.network](https://gateway.bobabeam.boba.network)             |
+|                   |                                                                                          |
+| ----------------- | ---------------------------------------------------------------------------------------- |
+| ChainID           | 1294                                                                                     |
+| RPC               | [https://bobabeam.boba.network](https://bobabeam.boba.network)                           |
+| Replica RPC       | [https://replica.bobabeam.boba.network](https://replica.bobabeam.boba.network)           |
+| Gateway           | [https://gateway.boba.network](https://gateway.boba.network)             |
 | Blockexplorer     | [https://blockexplorer.bobabeam.boba.network](https://blockexplorer.bobabeam.boba.network) |
-| Websocket         | [wss://wss.bobabeam.boba.network](wss://wss.bobabeam.boba.network)                         |
-| Replica Websocket | [wss://replica-wss.bobabeam.boba.network](wss://replica-wss.bobabeam.boba.network)         |
-| Gas Cap           | 50000000                                                                                   |
+| Websocket         | [wss://wss.bobabeam.boba.network](wss://wss.bobabeam.boba.network)                       |
+| Replica Websocket | [wss://replica-wss.bobabeam.boba.network](wss://replica-wss.bobabeam.boba.network)       |
+| Gas Cap           | 50000000                                                                                 |

--- a/boba_documentation/developer/network-parameters.md
+++ b/boba_documentation/developer/network-parameters.md
@@ -14,14 +14,14 @@ For **secondary addresses**, such as L2 Tokens, Messengers, and the DAO, please 
 
 ### Goerli Links and Endpoints
 
-|                |                                                                            |
-| -------------- | -------------------------------------------------------------------------- |
-| Goerli ChainID | 2888                                                                       |
-| Goerli RPC     | [https://goerli.boba.network](https://goerli.boba.network)                 |
-| Gateway        | [https://gateway.goerli.boba.network](https://gateway.goerli.boba.network) |
-| Blockexplorer  | [https://testnet.bobascan.com](https://testnet.bobascan.com)               |
-| Websocket      | [wss://wss.goerli.boba.network](wss://wss.goerli.boba.network)             |
-| Gas Cap        | 50000000                                                                   |
+|                |                                                                          |
+| -------------- | ------------------------------------------------------------------------ |
+| Goerli ChainID | 2888                                                                     |
+| Goerli RPC     | [https://goerli.boba.network](https://goerli.boba.network)               |
+| Gateway        | [https://gateway.boba.network](https://gateway.boba.network) |
+| Blockexplorer  | [https://testnet.bobascan.com](https://testnet.bobascan.com)             |
+| Websocket      | [wss://wss.goerli.boba.network](wss://wss.goerli.boba.network)           |
+| Gas Cap        | 50000000                                                                 |
 
 
 

--- a/boba_documentation/eng_updates/Engineering_update_5.md
+++ b/boba_documentation/eng_updates/Engineering_update_5.md
@@ -55,7 +55,7 @@ private async _updateGasPrice(): Promise<void> {
 
 * History support for the **webwallet**. Also, for mainnet, the webwallet now shows more information about transactions, so that wallet users can see the status of their transactions including block data, hashes, and cross-chain timestamps and receipts.
 
-* Name change for the **webwallet**. Reflecting its broad actual use (wallet, earn/stake, NFT minting, transaction histories, DAO interface, and more...) the webwallet will be renamed to **gateway**. The current endpoints will keep working, but in the near future, https://gateway.rinkeby.boba.network (and https://gateway.mainnet.boba.network) will serve as the main initial points of contact with the Boba L2.
+* Name change for the **webwallet**. Reflecting its broad actual use (wallet, earn/stake, NFT minting, transaction histories, DAO interface, and more...) the webwallet will be renamed to **gateway**. The current endpoints will keep working, but in the near future, https://gateway.boba.network will serve as the main initial points of contact with the Boba L2.
 
 ## 2. Hybrid Compute
 

--- a/faq.md
+++ b/faq.md
@@ -43,7 +43,7 @@ Many wallets now allow applications to trigger a popup to switch between network
 
 \* [The Boba **production** Network Ethereum](https://gateway.boba.network).
 
-\* [The Boba **test** Goerli Network](https://gateway.goerli.boba.network).
+\* [The Boba **test** Goerli Network](https://gateway.boba.network).
 
 If your wallet does not support this feature, you will have to connect manually. The exact process for connecting your wallet to a Boba Ethereum network depends on the specific wallet software you are using. To get started on Boba/Ethereum, you can use the available [community RPC endpoint](https://docs.boba.network/for-developers/network-parameters).
 
@@ -174,7 +174,7 @@ First, download MetaMask on your browser as a plug-in and set up a MetaMask wall
 
 ![Welcome to Metamask](./boba_documentation/.gitbook/assets/WELCOME-TO-METAMASK.png)
 
-After you’ve set up your MetaMask account, you can [connect to the Goerli network Testnet](https://gateway.goerli.boba.network). After connecting, follow these steps:
+After you’ve set up your MetaMask account, you can [connect to the Goerli network Testnet](https://gateway.boba.network). After connecting, follow these steps:
 
 * view your connection status displayed in the upper-right corner, along with a button that will allow you to select a chain to connect to.
 * click on the Boba icon. MetaMask will prompt you to connect to the Rinkeby Boba network.

--- a/faq.md
+++ b/faq.md
@@ -41,9 +41,7 @@ The high gas fees of Ethereum itself is a pretty strong incentive for developers
 
 Many wallets now allow applications to trigger a popup to switch between networks. If your wallet supports this feature, you will be automatically prompted to switch networks when an application wants to use the Boba Ethereum network. You can use these bridges to add the Boba network to your wallet:
 
-\* [The Boba **production** Network Ethereum](https://gateway.boba.network).
-
-\* [The Boba **test** Goerli Network](https://gateway.boba.network).
+\* [Universal gateway](https://gateway.boba.network).
 
 If your wallet does not support this feature, you will have to connect manually. The exact process for connecting your wallet to a Boba Ethereum network depends on the specific wallet software you are using. To get started on Boba/Ethereum, you can use the available [community RPC endpoint](https://docs.boba.network/for-developers/network-parameters).
 


### PR DESCRIPTION
## Overview

Fix gateway links as Goerli gateway is now part of main gateway (merged into one dapp)
Resolves #766 

## Changes

- Replace `gateway.goerli..` to `gateway...`

## Testing

