### PR TITLE
When bundler starts - verify the correct version of Entrypoint and EntrypointWrapper contract

### DIFF
--- a/packages/boba/bundler/src/BundlerServer.ts
+++ b/packages/boba/bundler/src/BundlerServer.ts
@@ -15,7 +15,7 @@ import { BundlerConfig } from './BundlerConfig'
 import { UserOpMethodHandler } from './UserOpMethodHandler'
 import { Server } from 'http'
 import { RpcError } from './utils'
-import { UserOperationStruct } from '@boba/accountabstraction'
+import { EntryPoint__factory, EntryPointWrapper__factory, UserOperationStruct } from "@boba/accountabstraction";
 import { DebugMethodHandler } from './DebugMethodHandler'
 
 import Debug from 'debug'
@@ -80,13 +80,24 @@ export class BundlerServer {
       maxPriorityFeePerGas: 0,
       signature: '0x',
     }
-    // TODO: https://github.com/bobanetwork/boba/issues/759
-    // // await EntryPoint__factory.connect(this.config.entryPoint,this.provider).callStatic.addStake(0)
-    // const err = await EntryPoint__factory.connect(this.config.entryPoint, this.provider).callStatic.simulateValidation(emptyUserOp)
-    //   .catch(e => e)
-    // if (err?.errorName !== 'FailedOp') {
-    //   this.fatal(`Invalid entryPoint contract at ${this.config.entryPoint}. wrong version?`)
-    // }
+
+    // doesn't use custom errors and doesn't exist in EntryPointWrapper directly yet
+    await EntryPoint__factory.connect(
+      this.config.entryPoint,
+      this.provider
+    ).callStatic.addStake(0)
+
+    const err = await EntryPointWrapper__factory.connect(
+      this.config.entryPointWrapper,
+      this.provider
+    )
+      .callStatic.simulateValidation(emptyUserOp)
+      .catch((e) => e)
+    if (err?.errorName !== 'FailedOp') {
+      this.fatal(
+        `Invalid entryPoint contract at ${this.config.entryPoint}. wrong version?`
+      )
+    }
     const bal = await this.provider.getBalance(this.wallet.address)
     console.log(
       'signer',


### PR DESCRIPTION
:clipboard: resolves #759

## Overview

Switch to EntryPointWrapper for version check. 

## Changes

- Switch to EntrypointWrapper instead of EntryPoint
- `.addStake()` only available on EntryPoint and doesn't use custom errors, thus kept as is

## Testing

Integration tests. 
