### PR TITLE
docker map of pks and Teleportation audit

### DIFF
--- a/boba_community/boba-node/docker-compose-bobabeam.yml
+++ b/boba_community/boba-node/docker-compose-bobabeam.yml
@@ -15,7 +15,6 @@ services:
       -  ../../ops/envs/dtl.env
     environment:
       << : *l1_rpc_dtl
-
       DATA_TRANSPORT_LAYER__L2_RPC_ENDPOINT: 'https://replica.bobabeam.boba.network'
       DATA_TRANSPORT_LAYER__SYNC_FROM_L1: 'false'
       DATA_TRANSPORT_LAYER__SYNC_FROM_L2: 'true'

--- a/ops/docker-compose-avalanche.yml
+++ b/ops/docker-compose-avalanche.yml
@@ -124,8 +124,7 @@ services:
       FRAUD_PROOF_WINDOW_SECONDS: 0
       L1_NODE_WEB3_URL: http://l1_chain:9650/ext/bc/C/rpc
       # these keys are hardhat's first 2 accounts, DO NOT use in production
-      << : *deployer_pk
-      << : *relayer_pk
+      << : [*deployer_pk, *relayer_pk]
       SEQUENCER_ADDRESS: "0x91ef3b19cdb344c5010358718e9347dd5cb2f362"
       PROPOSER_ADDRESS: "0xf31ca20d67bf4e3ddb4d7546c4a0983f3fa6ffea"
       # setting the whitelist owner to address(0) disables the whitelist
@@ -173,9 +172,7 @@ services:
       ADDRESS_MANAGER_ADDRESS: "0x52C84043CD9c865236f11d9Fc9F56aa003c1f922"
       URL: http://dtl:8081/addresses.json
       # DO NOT use in production
-      << : *deployer_pk
-      << : *relayer_pk
-      << : *fast-relayer_pk
+      << : [*deployer_pk, *relayer_pk, *fast-relayer_pk]
       RETRIES: 500
       DTL_REGISTRY_URL: http://dtl:8081/boba-addr.json
       # skip compilation when run in docker-compose, since the contracts
@@ -369,10 +366,7 @@ services:
       NO_NETWORK: 1
       L2_CHAINID: 31338 #unfortunately, elsewhere the L2_CHAINID is called CHAIN_ID
       RETRIES: 200
-      << : *integration_pk
-      << : *integration_2_pk
-      << : *integration_3_pk
-      << : *integration_4_pk
+      << : [*integration_pk, *integration_2_pk, *integration_3_pk, *integration_4_pk]
     volumes:
       - ~/result:/opt/optimism/integration-tests/result
     networks:

--- a/ops/docker-compose-bnb.yml
+++ b/ops/docker-compose-bnb.yml
@@ -99,8 +99,7 @@ services:
       FRAUD_PROOF_WINDOW_SECONDS: 0
       L1_NODE_WEB3_URL: http://l1_chain:8545
       # these keys are hardhat's first 2 accounts, DO NOT use in production
-      << : *deployer_pk
-      << : *relayer_pk
+      << : [*deployer_pk, *relayer_pk]
       SEQUENCER_ADDRESS: "0xA2bC4Cf857f3D7a22b29c71774B4d8f25cc7edD0"
       PROPOSER_ADDRESS: "0x59b02D4d2F94ea5c55230715a58EBb0b703bCD4B"
       # setting the whitelist owner to address(0) disables the whitelist
@@ -145,9 +144,7 @@ services:
       ADDRESS_MANAGER_ADDRESS: "0xC194E4CFa59D2DfC520217dA22E23DF8D4658a37"
       URL: http://dtl:8081/addresses.json
       # DO NOT use in production
-      << : *deployer_pk
-      << : *relayer_pk
-      << : *fast-relayer_pk
+      << : [*deployer_pk, *relayer_pk, *fast-relayer_pk]
       RETRIES: 500
       DTL_REGISTRY_URL: http://dtl:8081/boba-addr.json
       # skip compilation when run in docker-compose, since the contracts
@@ -339,10 +336,7 @@ services:
       NO_NETWORK: 1
       L2_CHAINID: 31338 #unfortunately, elsewhere the L2_CHAINID is called CHAIN_ID
       RETRIES: 500
-      << : *integration_pk
-      << : *integration_2_pk
-      << : *integration_3_pk
-      << : *integration_4_pk
+      << : [*integration_pk, *integration_2_pk, *integration_3_pk, *integration_4_pk]
     volumes:
        - ~/result:/opt/optimism/integration-tests/result
     networks:

--- a/ops/docker-compose-fantom.yml
+++ b/ops/docker-compose-fantom.yml
@@ -83,8 +83,7 @@ services:
       FRAUD_PROOF_WINDOW_SECONDS: 0
       L1_NODE_WEB3_URL: http://l1_chain:18545
       # these keys are hardhat's first 2 accounts, DO NOT use in production
-      << : *deployer_pk
-      << : *relayer_pk
+      << : [*deployer_pk, *relayer_pk]
       SEQUENCER_ADDRESS: "0x6236C601FfD52c4793e3B49B15bcdc1137E6339D"
       PROPOSER_ADDRESS: "0x814B1fac2aE5AbBf40Bb289b263ED4c367C50AA9"
       # setting the whitelist owner to address(0) disables the whitelist
@@ -129,9 +128,7 @@ services:
       ADDRESS_MANAGER_ADDRESS: "0xf536cAF1a894E09945E649FCE3032E8E03ECb9A0"
       URL: http://dtl:8081/addresses.json
       # DO NOT use in production
-      << : *deployer_pk
-      << : *relayer_pk
-      << : *fast-relayer_pk
+      << : [*deployer_pk, *relayer_pk, *fast-relayer_pk]
       RETRIES: 200
       DTL_REGISTRY_URL: http://dtl:8081/boba-addr.json
       # skip compilation when run in docker-compose, since the contracts
@@ -310,10 +307,7 @@ services:
       NO_NETWORK: 1
       L2_CHAINID: 31338 #unfortunately, elsewhere the L2_CHAINID is called CHAIN_ID
       RETRIES: 200
-      << : *integration_pk
-      << : *integration_2_pk
-      << : *integration_3_pk
-      << : *integration_4_pk
+      << : [*integration_pk, *integration_2_pk, *integration_3_pk, *integration_4_pk]
     volumes:
        - ~/result:/opt/optimism/integration-tests/result
 

--- a/ops/docker-compose-moonbeam.yml
+++ b/ops/docker-compose-moonbeam.yml
@@ -95,8 +95,7 @@ services:
       FRAUD_PROOF_WINDOW_SECONDS: 0
       L1_NODE_WEB3_URL: http://l1_chain:9933
       # these keys are hardhat's first 2 accounts, DO NOT use in production
-      << : *deployer_pk
-      << : *relayer_pk
+      << : [*deployer_pk, *relayer_pk]
       SEQUENCER_ADDRESS: "0x3Cd0A705a2DC65e5b1E1205896BaA2be8A07c6e0"
       PROPOSER_ADDRESS: "0x798d4Ba9baf0064Ec19eB4F0a1a45785ae9D6DFc"
       # setting the whitelist owner to address(0) disables the whitelist
@@ -140,9 +139,7 @@ services:
       ADDRESS_MANAGER_ADDRESS: "0xc01Ee7f10EA4aF4673cFff62710E1D7792aBa8f3"
       URL: http://dtl:8081/addresses.json
       # DO NOT use in production
-      << : *deployer_pk
-      << : *relayer_pk
-      << : *fast-relayer_pk
+      << : [*deployer_pk, *relayer_pk, *fast-relayer_pk]
       RETRIES: 200
       DTL_REGISTRY_URL: http://dtl:8081/boba-addr.json
       # skip compilation when run in docker-compose, since the contracts
@@ -321,9 +318,7 @@ services:
       ENABLE_GAS_REPORT: 1
       NO_NETWORK: 1
       L2_CHAINID: 31338 #unfortunately, elsewhere the L2_CHAINID is called CHAIN_ID
-      << : *integration_pk
-      << : *integration_2_pk
-      << : *integration_3_pk
+      << : [*integration_pk, *integration_2_pk, *integration_3_pk]
     volumes:
        - ~/result:/opt/optimism/integration-tests/result
 

--- a/packages/boba/contracts/contracts/Teleportation.sol
+++ b/packages/boba/contracts/contracts/Teleportation.sol
@@ -7,10 +7,6 @@ import '@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol';
 import "@openzeppelin/contracts-upgradeable/security/PausableUpgradeable.sol";
 
 /**
- Note: This contract has not been audited, exercise caution when using this on mainnet
- */
-
-/**
  * @title Teleportation
  *
  * Shout out to optimisim for providing the inspiration for this contract:


### PR DESCRIPTION
Docker version 23.0.5, build bc4487a stops accepting a list of variable keys so here'a fix for that.

## Overview

Teleportation has been audited so we can remove that comment

## Changes

Describe your changes and implementation choices. More details make PRs easier to review.

- list of variables in dc
- remove comment

## Testing

/