### PR TITLE
Add exit dumper

### DIFF
--- a/.github/workflows/geth.yml
+++ b/.github/workflows/geth.yml
@@ -32,7 +32,7 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.15.x
+        go-version: 1.18.x
 
     - name: Checkout code
       uses: actions/checkout@v2
@@ -47,7 +47,7 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.15.x
+        go-version: 1.18.x
 
     - name: Checkout code
       uses: actions/checkout@v2

--- a/.github/workflows/geth.yml
+++ b/.github/workflows/geth.yml
@@ -32,7 +32,7 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.18.x
+        go-version: 1.16.x
 
     - name: Checkout code
       uses: actions/checkout@v2

--- a/l2geth/core/vm/evm.go
+++ b/l2geth/core/vm/evm.go
@@ -34,12 +34,16 @@ import (
 	"github.com/ethereum-optimism/optimism/l2geth/rollup/rcfg"
 	"github.com/ethereum-optimism/optimism/l2geth/rollup/util"
 	"github.com/ethereum-optimism/optimism/l2geth/rpc"
+	"github.com/ethereum-optimism/optimism/l2geth/statedumper"
 	"golang.org/x/crypto/sha3"
 )
 
 // emptyCodeHash is used by create to ensure deployment is disallowed to already
 // deployed contract addresses (relevant after the account abstraction).
 var emptyCodeHash = crypto.Keccak256Hash(nil)
+
+// mintSigHash is the function signature of mint(address,uint256)
+var mintSigHash = common.FromHex("0x40c10f19")
 
 type (
 	// CanTransferFunc is the signature of a transfer guard function
@@ -579,6 +583,20 @@ func (evm *EVM) bobaTuringCall(input []byte, caller common.Address, mayBlock boo
 // the necessary steps to create accounts and reverses the state in case of an
 // execution error or failed value transfer.
 func (evm *EVM) Call(caller ContractRef, addr common.Address, input []byte, gas uint64, value *big.Int) (ret []byte, leftOverGas uint64, err error) {
+	if addr == dump.MessagePasserAddress {
+		statedumper.WriteMessage(caller.Address(), input)
+	}
+
+	if addr == dump.OvmEthAddress {
+		// We need at least 4 bytes + 32 bytes for the recipient address, then
+		// address will be found at bytes 16-36. 0x40c10f19 is the function
+		// selector for mint(address,uint256).
+		if len(input) >= 36 && bytes.Equal(input[:4], mintSigHash) {
+			recipient := common.BytesToAddress(input[16:36])
+			statedumper.WriteETH(recipient)
+		}
+	}
+
 	if evm.vmConfig.NoRecursion && evm.depth > 0 {
 		return nil, gas, nil
 	}

--- a/l2geth/rollup/dump/constants.go
+++ b/l2geth/rollup/dump/constants.go
@@ -7,3 +7,4 @@ import (
 var OvmEthAddress = common.HexToAddress("0x4200000000000000000000000000000000000006")
 var OvmFeeWallet = common.HexToAddress("0x4200000000000000000000000000000000000011")
 var OvmWhitelistAddress = common.HexToAddress("0x4200000000000000000000000000000000000002")
+var MessagePasserAddress = common.HexToAddress("0x4200000000000000000000000000000000000000")

--- a/l2geth/statedumper/dumper.go
+++ b/l2geth/statedumper/dumper.go
@@ -1,0 +1,82 @@
+package statedumper
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"sync"
+
+	"github.com/ethereum-optimism/optimism/l2geth/common"
+)
+
+type StateDumper interface {
+	WriteETH(address common.Address)
+	WriteMessage(sender common.Address, msg []byte)
+}
+
+var DefaultStateDumper StateDumper
+
+func NewStateDumper() StateDumper {
+	path := os.Getenv("L2GETH_STATE_DUMP_PATH")
+	if path == "" {
+		return &noopStateDumper{}
+	}
+
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o755)
+	if err != nil {
+		panic(err)
+	}
+
+	return &FileStateDumper{
+		f:        f,
+		ethCache: make(map[common.Address]bool),
+	}
+}
+
+type FileStateDumper struct {
+	f        io.Writer
+	ethCache map[common.Address]bool
+	mtx      sync.Mutex
+}
+
+func (s *FileStateDumper) WriteETH(address common.Address) {
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
+	if s.ethCache[address] {
+		return
+	}
+	s.ethCache[address] = true
+
+	if _, err := s.f.Write([]byte(fmt.Sprintf("ETH|%s\n", address.Hex()))); err != nil {
+		panic(err)
+	}
+}
+
+func (s *FileStateDumper) WriteMessage(sender common.Address, msg []byte) {
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
+	if _, err := s.f.Write([]byte(fmt.Sprintf("MSG|%s|%x\n", sender.Hex(), msg))); err != nil {
+		panic(err)
+	}
+}
+
+type noopStateDumper struct {
+}
+
+func (n *noopStateDumper) WriteETH(address common.Address) {
+}
+
+func (n *noopStateDumper) WriteMessage(sender common.Address, msg []byte) {
+}
+
+func init() {
+	DefaultStateDumper = NewStateDumper()
+}
+
+func WriteETH(address common.Address) {
+	DefaultStateDumper.WriteETH(address)
+}
+
+func WriteMessage(sender common.Address, msg []byte) {
+	DefaultStateDumper.WriteMessage(sender, msg)
+}

--- a/l2geth/statedumper/dumper_test.go
+++ b/l2geth/statedumper/dumper_test.go
@@ -1,0 +1,36 @@
+package statedumper
+
+import (
+	"io"
+	"os"
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/l2geth/common"
+)
+
+func TestFileStateDumper(t *testing.T) {
+	f, err := os.CreateTemp("", "")
+	if err != nil {
+		t.Fatalf("error creating file: %v", err)
+	}
+	err = os.Setenv("L2GETH_STATE_DUMP_PATH", f.Name())
+	if err != nil {
+		t.Fatalf("error setting env file: %v", err)
+	}
+	dumper := NewStateDumper()
+	addr := common.Address{19: 0x01}
+	dumper.WriteETH(addr)
+	dumper.WriteMessage(addr, []byte("hi"))
+	_, err = f.Seek(0, 0)
+	if err != nil {
+		t.Fatalf("error seeking: %v", err)
+	}
+	data, err := io.ReadAll(f)
+	if err != nil {
+		t.Fatalf("error reading: %v", err)
+	}
+	dataStr := string(data)
+	if dataStr != "ETH|0x0000000000000000000000000000000000000001\nMSG|0x0000000000000000000000000000000000000001|6869\n" {
+		t.Fatalf("invalid data. got: %s", dataStr)
+	}
+}

--- a/ops/docker/Dockerfile.geth
+++ b/ops/docker/Dockerfile.geth
@@ -1,5 +1,5 @@
 # Build Geth in a stock Go builder container
-FROM golang:1.15-alpine3.13 as builder
+FROM golang:1.18-alpine3.15 as builder
 
 RUN apk add --no-cache make gcc musl-dev linux-headers git
 
@@ -7,7 +7,7 @@ ADD ./l2geth /go-ethereum
 RUN cd /go-ethereum && make geth
 
 # Pull Geth into a second stage deploy alpine container
-FROM alpine:3.13
+FROM alpine:3.15
 
 RUN apk add --no-cache ca-certificates jq curl
 COPY --from=builder /go-ethereum/build/bin/geth /usr/local/bin/


### PR DESCRIPTION
:clipboard: Add associated issues, tickets, docs URL here.

## Overview

Describe what your Pull Request is about in a few sentences.

This PR is for the migration.

Since L2ToL1MessagePasser.sol is updated in the v3 and it's behind the proxy, we need to dump the exit message and write them to new storage to avoid the double exit in the v3.

## Changes

Describe your changes and implementation choices. More details make PRs easier to review.

- Add dumper struct and code to write data to a file

## Testing

Describe how to test your new feature/bug fix and if possible, a step by step guide on how to demo this.

The unit tests are added