### PR TITLE
remove moonbeam and fantom integration tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -181,17 +181,6 @@ jobs:
           test_folder: "eth-l2"
       - report-integration-tests
 
-  integration-tests-moonbeam:
-    executor: intergration-tests-executor
-    parallelism: 4
-    steps:
-      - download-solidity-compilers
-      - run-integration-tests:
-          docker_compose_file: "docker-compose-moonbeam.yml"
-          docker_compose_side_file: "docker-compose-moonbeam-side.yml"
-          test_folder: "alt-l2"
-      - report-integration-tests
-
   integration-tests-avalanche:
     executor: intergration-tests-executor
     parallelism: 4
@@ -214,25 +203,12 @@ jobs:
           test_folder: "alt-l2"
       - report-integration-tests
 
-  integration-tests-fantom:
-    executor: intergration-tests-executor
-    parallelism: 4
-    steps:
-      - download-solidity-compilers
-      - run-integration-tests:
-          docker_compose_file: "docker-compose-fantom.yml"
-          docker_compose_side_file: "docker-compose-fantom-side.yml"
-          test_folder: "alt-l2"
-      - report-integration-tests
-
 workflows:
   main:
     jobs:
       - integration-tests
-      - integration-tests-moonbeam
       - integration-tests-avalanche
       - integration-tests-bnb
-      - integration-tests-fantom
       - go-lint-test-build:
           name: proxyd-tests
           binary_name: proxyd

--- a/integration-tests/test/alt-l2/shared/utils.ts
+++ b/integration-tests/test/alt-l2/shared/utils.ts
@@ -24,13 +24,9 @@ export const isLiveNetwork = () => {
 }
 
 export const HARDHAT_CHAIN_ID = 31337
-export const MOONBEAM_CHAIN_ID = 1281
-export const FANTOM_CHAIN_ID = 4003
 export const AVALANCHE_CHAIN_ID = 43112
 export const BNB_CHAIN_ID = 99
 export const NON_ETHEREUM_CHAIN = [
-  MOONBEAM_CHAIN_ID,
-  FANTOM_CHAIN_ID,
   AVALANCHE_CHAIN_ID,
   BNB_CHAIN_ID,
 ]


### PR DESCRIPTION
:clipboard: https://github.com/bobanetwork/boba/issues/805

## Overview

disables and removes integration tests for moonbeam and fantom

NOTE: This does not remove moonbeam or fantom from the repo. (for eg - gateway, subgraph, teleporation etc)
This only turns off testing

## Changes

- disable running integration test on circleCI

## Testing

CircleCI
