### PR TITLE
[AA]chore: make hosted and AM names consistent

### DIFF
--- a/integration-tests/test/alt-l2/boba_aa_alt_fee_token.spec.ts
+++ b/integration-tests/test/alt-l2/boba_aa_alt_fee_token.spec.ts
@@ -40,7 +40,7 @@ describe('AA Alt-L1 Alt Token as Paymaster Fee Test\n', async () => {
 
   before(async () => {
     env = await OptimismEnv.new()
-    entryPointAddress = env.addressesAABOBA.L2_BOBA_EntryPoint
+    entryPointAddress = env.addressesAABOBA.L2_Boba_EntryPoint
 
     SampleRecipient__factory = new ContractFactory(
       SampleRecipientJson.abi,

--- a/integration-tests/test/alt-l2/boba_aa_bundler.spec.ts
+++ b/integration-tests/test/alt-l2/boba_aa_bundler.spec.ts
@@ -43,7 +43,7 @@ describe('AA Bundler Test\n', async () => {
 
   before(async () => {
     env = await OptimismEnv.new()
-    const entryPointAddress = env.addressesAABOBA.L2_BOBA_EntryPoint
+    const entryPointAddress = env.addressesAABOBA.L2_Boba_EntryPoint
 
     entryPoint = new Contract(
       entryPointAddress,

--- a/integration-tests/test/alt-l2/boba_aa_wallet.spec.ts
+++ b/integration-tests/test/alt-l2/boba_aa_wallet.spec.ts
@@ -26,7 +26,7 @@ describe('AA Wallet Test\n', async () => {
 
   before(async () => {
     env = await OptimismEnv.new()
-    entryPointAddress = env.addressesAABOBA.L2_BOBA_EntryPoint
+    entryPointAddress = env.addressesAABOBA.L2_Boba_EntryPoint
 
     SimpleAccount__factory = new ContractFactory(
       SimpleAccountFactoryJson.abi,

--- a/integration-tests/test/eth-l2/boba_aa_bundler.spec.ts
+++ b/integration-tests/test/eth-l2/boba_aa_bundler.spec.ts
@@ -43,7 +43,7 @@ describe('AA Bundler Test\n', async () => {
 
   before(async () => {
     env = await OptimismEnv.new()
-    const entryPointAddress = env.addressesAABOBA.L2_BOBA_EntryPoint
+    const entryPointAddress = env.addressesAABOBA.L2_Boba_EntryPoint
 
     entryPoint = new Contract(
       entryPointAddress,

--- a/integration-tests/test/eth-l2/boba_aa_fee_alt_token.spec.ts
+++ b/integration-tests/test/eth-l2/boba_aa_fee_alt_token.spec.ts
@@ -45,7 +45,7 @@ describe('AA Alt Fee Token Test\n', async () => {
 
   before(async () => {
     env = await OptimismEnv.new()
-    entryPointAddress = env.addressesAABOBA.L2_BOBA_EntryPoint
+    entryPointAddress = env.addressesAABOBA.L2_Boba_EntryPoint
 
     SampleRecipient__factory = new ContractFactory(
       SampleRecipientJson.abi,

--- a/integration-tests/test/eth-l2/boba_aa_fee_boba.spec.ts
+++ b/integration-tests/test/eth-l2/boba_aa_fee_boba.spec.ts
@@ -43,7 +43,7 @@ describe('AA Boba as Fee token Test\n', async () => {
 
   before(async () => {
     env = await OptimismEnv.new()
-    entryPointAddress = env.addressesAABOBA.L2_BOBA_EntryPoint
+    entryPointAddress = env.addressesAABOBA.L2_Boba_EntryPoint
 
     SampleRecipient__factory = new ContractFactory(
       SampleRecipientJson.abi,

--- a/integration-tests/test/eth-l2/boba_aa_sponsoring_fee.spec.ts
+++ b/integration-tests/test/eth-l2/boba_aa_sponsoring_fee.spec.ts
@@ -39,7 +39,7 @@ describe('Sponsoring Tx\n', async () => {
 
   before(async () => {
     env = await OptimismEnv.new()
-    entryPointAddress = env.addressesAABOBA.L2_BOBA_EntryPoint
+    entryPointAddress = env.addressesAABOBA.L2_Boba_EntryPoint
 
     SampleRecipient__factory = new ContractFactory(
       SampleRecipientJson.abi,

--- a/integration-tests/test/eth-l2/boba_aa_wallet.spec.ts
+++ b/integration-tests/test/eth-l2/boba_aa_wallet.spec.ts
@@ -27,7 +27,7 @@ describe('AA Wallet Test\n', async () => {
 
   before(async () => {
     env = await OptimismEnv.new()
-    entryPointAddress = env.addressesAABOBA.L2_BOBA_EntryPoint
+    entryPointAddress = env.addressesAABOBA.L2_Boba_EntryPoint
 
     SimpleAccount__factory = new ContractFactory(
       SimpleAccountFactoryJson.abi,

--- a/ops/scripts/integration-tests.sh
+++ b/ops/scripts/integration-tests.sh
@@ -19,7 +19,7 @@ echo "Calling: "$AA_BOBA_URL
 if [[ ! -z "$AA_BOBA_URL" ]]; then
     # get the addrs from the URL provided
     ADDRESSES=$(curl --fail --show-error --silent --retry-connrefused --retry $RETRIES --retry-delay 5 $AA_BOBA_URL)
-    echo $ADDRESSES | jq -r '.L2_BOBA_EntryPoint'
+    echo $ADDRESSES | jq -r '.L2_Boba_EntryPoint'
 fi
 echo "Calling: "$L2_URL
 # wait for the sequencer to be up

--- a/packages/boba/account-abstraction/deploy/5-dump-addresses.ts
+++ b/packages/boba/account-abstraction/deploy/5-dump-addresses.ts
@@ -10,7 +10,7 @@ const deployFn: DeployFunction = async (hre) => {
   for (const key in deployments) {
     if (deployments.hasOwnProperty(key)) {
         if (key == 'EntryPoint') {
-          contracts['L2_BOBA_'+key] = deployments[key].address
+          contracts['L2_Boba_'+key] = deployments[key].address
         } else {
           contracts['L2_'+key] = deployments[key].address
         }

--- a/packages/boba/account-abstraction/deployments/boba_bnb_testnet/addresses.json
+++ b/packages/boba/account-abstraction/deployments/boba_bnb_testnet/addresses.json
@@ -1,4 +1,4 @@
 {
-    "L2_BOBA_EntryPoint": "0xb6b46ef8aa4edce3f3a1b671e9fba945cc8b8642",
+    "L2_Boba_EntryPoint": "0xb6b46ef8aa4edce3f3a1b671e9fba945cc8b8642",
     "L2_EntryPointWrapper": "0x5fd867caa5ce9a52174d6630ec4ee9e87d818bfe"
 }

--- a/packages/boba/account-abstraction/deployments/boba_goerli/addresses.json
+++ b/packages/boba/account-abstraction/deployments/boba_goerli/addresses.json
@@ -1,5 +1,5 @@
 {
-    "L2_BOBA_EntryPoint": "0xa6e2cbb294d3b84e7900daf0052ffe26bb1328ff",
+    "L2_Boba_EntryPoint": "0xa6e2cbb294d3b84e7900daf0052ffe26bb1328ff",
     "L2_BobaDepositPaymaster": "0x06C1D387270E322D3B7b9Bed6777aaF8Aead4707",
     "L2_BobaVerifyingPaymaster": "0xAa210aEC4649C92E1d9b7267AD767eF3dFa20677",
     "L2_EntryPointWrapper": "0xb1b04b6ea9e013c0ff1970965d5d6d6e637e98d7"


### PR DESCRIPTION
:clipboard: 

## Overview

makes naming of addresses hosted on the DTL and the addresses registered on the AM consistent

## Changes

- change L2_BOBA_EntryPoint to L2_Boba_EntryPoint

## Testing

all integ tests should work, ci logs
