### PR TITLE
HybridCompute starter goerli redeployment

### DIFF
--- a/boba_community/boba-node/state-dumps/goerli/boba-addr.json
+++ b/boba_community/boba-node/state-dumps/goerli/boba-addr.json
@@ -70,4 +70,5 @@
   "Proxy__ETHUSD_AggregatorHC": "0x9e28dE704435871af476460B456Ec741fE5DE24f",
   "ETHUSD_AggregatorHC": "0x300f35972189d5FbEe140E552Dac80df85E6521C",
   "L2StandardTokenFactory": "0xD2ae16D8c66ac7bc1Cf3c9e5d6bfE5f76BeDb826",
+  "HybridComputeHelperFactory": "0xFeED2Dc24E3CCd9594B5122318F1b6c037492652"
 }

--- a/boba_community/hc-start/README.md
+++ b/boba_community/hc-start/README.md
@@ -34,7 +34,7 @@ In this package you'll find the actual solidity smart contracts which have been 
 
 This package contains the react app the user actually navigates through.
 
-* **Rinkeby**: [hcb.goerli.boba.network](https://hcb.goerli.boba.network/)
+* **Goerli**: [hcb.goerli.boba.network](https://hcb.goerli.boba.network/)
 * **Mainnet**: [hcb.boba.network](https://hcb.boba.network/)
 
 

--- a/boba_community/hc-start/packages/contracts/gen/types/HybridComputeHelper.ts
+++ b/boba_community/hc-start/packages/contracts/gen/types/HybridComputeHelper.ts
@@ -30,10 +30,13 @@ import type {
 
 export interface HybridComputeHelperInterface extends utils.Interface {
   functions: {
+    "Get42(uint32,uint256)": FunctionFragment;
     "GetRandom(uint32,uint256)": FunctionFragment;
     "GetResponse(uint32,string,bytes)": FunctionFragment;
+    "Turing42()": FunctionFragment;
     "TuringRandom()": FunctionFragment;
     "TuringTx(string,bytes)": FunctionFragment;
+    "TuringTxV2(string,bytes)": FunctionFragment;
     "addPermittedCaller(address)": FunctionFragment;
     "addPermittedCallers(address[])": FunctionFragment;
     "checkPermittedCaller(address)": FunctionFragment;
@@ -50,10 +53,13 @@ export interface HybridComputeHelperInterface extends utils.Interface {
 
   getFunction(
     nameOrSignatureOrTopic:
+      | "Get42"
       | "GetRandom"
       | "GetResponse"
+      | "Turing42"
       | "TuringRandom"
       | "TuringTx"
+      | "TuringTxV2"
       | "addPermittedCaller"
       | "addPermittedCallers"
       | "checkPermittedCaller"
@@ -69,6 +75,10 @@ export interface HybridComputeHelperInterface extends utils.Interface {
   ): FunctionFragment;
 
   encodeFunctionData(
+    functionFragment: "Get42",
+    values: [PromiseOrValue<BigNumberish>, PromiseOrValue<BigNumberish>]
+  ): string;
+  encodeFunctionData(
     functionFragment: "GetRandom",
     values: [PromiseOrValue<BigNumberish>, PromiseOrValue<BigNumberish>]
   ): string;
@@ -80,12 +90,17 @@ export interface HybridComputeHelperInterface extends utils.Interface {
       PromiseOrValue<BytesLike>
     ]
   ): string;
+  encodeFunctionData(functionFragment: "Turing42", values?: undefined): string;
   encodeFunctionData(
     functionFragment: "TuringRandom",
     values?: undefined
   ): string;
   encodeFunctionData(
     functionFragment: "TuringTx",
+    values: [PromiseOrValue<string>, PromiseOrValue<BytesLike>]
+  ): string;
+  encodeFunctionData(
+    functionFragment: "TuringTxV2",
     values: [PromiseOrValue<string>, PromiseOrValue<BytesLike>]
   ): string;
   encodeFunctionData(
@@ -134,16 +149,19 @@ export interface HybridComputeHelperInterface extends utils.Interface {
     values: [PromiseOrValue<string>, PromiseOrValue<BytesLike>]
   ): string;
 
+  decodeFunctionResult(functionFragment: "Get42", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "GetRandom", data: BytesLike): Result;
   decodeFunctionResult(
     functionFragment: "GetResponse",
     data: BytesLike
   ): Result;
+  decodeFunctionResult(functionFragment: "Turing42", data: BytesLike): Result;
   decodeFunctionResult(
     functionFragment: "TuringRandom",
     data: BytesLike
   ): Result;
   decodeFunctionResult(functionFragment: "TuringTx", data: BytesLike): Result;
+  decodeFunctionResult(functionFragment: "TuringTxV2", data: BytesLike): Result;
   decodeFunctionResult(
     functionFragment: "addPermittedCaller",
     data: BytesLike
@@ -189,6 +207,7 @@ export interface HybridComputeHelperInterface extends utils.Interface {
     "AdminChanged(address,address)": EventFragment;
     "BeaconUpgraded(address)": EventFragment;
     "CheckPermittedCaller(address,bool)": EventFragment;
+    "Offchain42(uint256,uint256)": EventFragment;
     "OffchainRandom(uint256,uint256)": EventFragment;
     "OffchainResponse(uint256,bytes)": EventFragment;
     "OwnershipTransferred(address,address)": EventFragment;
@@ -200,6 +219,7 @@ export interface HybridComputeHelperInterface extends utils.Interface {
   getEvent(nameOrSignatureOrTopic: "AdminChanged"): EventFragment;
   getEvent(nameOrSignatureOrTopic: "BeaconUpgraded"): EventFragment;
   getEvent(nameOrSignatureOrTopic: "CheckPermittedCaller"): EventFragment;
+  getEvent(nameOrSignatureOrTopic: "Offchain42"): EventFragment;
   getEvent(nameOrSignatureOrTopic: "OffchainRandom"): EventFragment;
   getEvent(nameOrSignatureOrTopic: "OffchainResponse"): EventFragment;
   getEvent(nameOrSignatureOrTopic: "OwnershipTransferred"): EventFragment;
@@ -250,6 +270,17 @@ export type CheckPermittedCallerEvent = TypedEvent<
 
 export type CheckPermittedCallerEventFilter =
   TypedEventFilter<CheckPermittedCallerEvent>;
+
+export interface Offchain42EventObject {
+  version: BigNumber;
+  random: BigNumber;
+}
+export type Offchain42Event = TypedEvent<
+  [BigNumber, BigNumber],
+  Offchain42EventObject
+>;
+
+export type Offchain42EventFilter = TypedEventFilter<Offchain42Event>;
 
 export interface OffchainRandomEventObject {
   version: BigNumber;
@@ -331,6 +362,12 @@ export interface HybridComputeHelper extends BaseContract {
   removeListener: OnEvent<this>;
 
   functions: {
+    Get42(
+      rType: PromiseOrValue<BigNumberish>,
+      _random: PromiseOrValue<BigNumberish>,
+      overrides?: Overrides & { from?: PromiseOrValue<string> }
+    ): Promise<ContractTransaction>;
+
     GetRandom(
       rType: PromiseOrValue<BigNumberish>,
       _random: PromiseOrValue<BigNumberish>,
@@ -344,11 +381,21 @@ export interface HybridComputeHelper extends BaseContract {
       overrides?: Overrides & { from?: PromiseOrValue<string> }
     ): Promise<ContractTransaction>;
 
+    Turing42(
+      overrides?: Overrides & { from?: PromiseOrValue<string> }
+    ): Promise<ContractTransaction>;
+
     TuringRandom(
       overrides?: Overrides & { from?: PromiseOrValue<string> }
     ): Promise<ContractTransaction>;
 
     TuringTx(
+      _url: PromiseOrValue<string>,
+      _payload: PromiseOrValue<BytesLike>,
+      overrides?: Overrides & { from?: PromiseOrValue<string> }
+    ): Promise<ContractTransaction>;
+
+    TuringTxV2(
       _url: PromiseOrValue<string>,
       _payload: PromiseOrValue<BytesLike>,
       overrides?: Overrides & { from?: PromiseOrValue<string> }
@@ -411,6 +458,12 @@ export interface HybridComputeHelper extends BaseContract {
     ): Promise<ContractTransaction>;
   };
 
+  Get42(
+    rType: PromiseOrValue<BigNumberish>,
+    _random: PromiseOrValue<BigNumberish>,
+    overrides?: Overrides & { from?: PromiseOrValue<string> }
+  ): Promise<ContractTransaction>;
+
   GetRandom(
     rType: PromiseOrValue<BigNumberish>,
     _random: PromiseOrValue<BigNumberish>,
@@ -424,11 +477,21 @@ export interface HybridComputeHelper extends BaseContract {
     overrides?: Overrides & { from?: PromiseOrValue<string> }
   ): Promise<ContractTransaction>;
 
+  Turing42(
+    overrides?: Overrides & { from?: PromiseOrValue<string> }
+  ): Promise<ContractTransaction>;
+
   TuringRandom(
     overrides?: Overrides & { from?: PromiseOrValue<string> }
   ): Promise<ContractTransaction>;
 
   TuringTx(
+    _url: PromiseOrValue<string>,
+    _payload: PromiseOrValue<BytesLike>,
+    overrides?: Overrides & { from?: PromiseOrValue<string> }
+  ): Promise<ContractTransaction>;
+
+  TuringTxV2(
     _url: PromiseOrValue<string>,
     _payload: PromiseOrValue<BytesLike>,
     overrides?: Overrides & { from?: PromiseOrValue<string> }
@@ -491,6 +554,12 @@ export interface HybridComputeHelper extends BaseContract {
   ): Promise<ContractTransaction>;
 
   callStatic: {
+    Get42(
+      rType: PromiseOrValue<BigNumberish>,
+      _random: PromiseOrValue<BigNumberish>,
+      overrides?: CallOverrides
+    ): Promise<BigNumber>;
+
     GetRandom(
       rType: PromiseOrValue<BigNumberish>,
       _random: PromiseOrValue<BigNumberish>,
@@ -504,9 +573,17 @@ export interface HybridComputeHelper extends BaseContract {
       overrides?: CallOverrides
     ): Promise<string>;
 
+    Turing42(overrides?: CallOverrides): Promise<BigNumber>;
+
     TuringRandom(overrides?: CallOverrides): Promise<BigNumber>;
 
     TuringTx(
+      _url: PromiseOrValue<string>,
+      _payload: PromiseOrValue<BytesLike>,
+      overrides?: CallOverrides
+    ): Promise<string>;
+
+    TuringTxV2(
       _url: PromiseOrValue<string>,
       _payload: PromiseOrValue<BytesLike>,
       overrides?: CallOverrides
@@ -596,6 +673,12 @@ export interface HybridComputeHelper extends BaseContract {
       permitted?: null
     ): CheckPermittedCallerEventFilter;
 
+    "Offchain42(uint256,uint256)"(
+      version?: null,
+      random?: null
+    ): Offchain42EventFilter;
+    Offchain42(version?: null, random?: null): Offchain42EventFilter;
+
     "OffchainRandom(uint256,uint256)"(
       version?: null,
       random?: null
@@ -636,6 +719,12 @@ export interface HybridComputeHelper extends BaseContract {
   };
 
   estimateGas: {
+    Get42(
+      rType: PromiseOrValue<BigNumberish>,
+      _random: PromiseOrValue<BigNumberish>,
+      overrides?: Overrides & { from?: PromiseOrValue<string> }
+    ): Promise<BigNumber>;
+
     GetRandom(
       rType: PromiseOrValue<BigNumberish>,
       _random: PromiseOrValue<BigNumberish>,
@@ -649,11 +738,21 @@ export interface HybridComputeHelper extends BaseContract {
       overrides?: Overrides & { from?: PromiseOrValue<string> }
     ): Promise<BigNumber>;
 
+    Turing42(
+      overrides?: Overrides & { from?: PromiseOrValue<string> }
+    ): Promise<BigNumber>;
+
     TuringRandom(
       overrides?: Overrides & { from?: PromiseOrValue<string> }
     ): Promise<BigNumber>;
 
     TuringTx(
+      _url: PromiseOrValue<string>,
+      _payload: PromiseOrValue<BytesLike>,
+      overrides?: Overrides & { from?: PromiseOrValue<string> }
+    ): Promise<BigNumber>;
+
+    TuringTxV2(
       _url: PromiseOrValue<string>,
       _payload: PromiseOrValue<BytesLike>,
       overrides?: Overrides & { from?: PromiseOrValue<string> }
@@ -717,6 +816,12 @@ export interface HybridComputeHelper extends BaseContract {
   };
 
   populateTransaction: {
+    Get42(
+      rType: PromiseOrValue<BigNumberish>,
+      _random: PromiseOrValue<BigNumberish>,
+      overrides?: Overrides & { from?: PromiseOrValue<string> }
+    ): Promise<PopulatedTransaction>;
+
     GetRandom(
       rType: PromiseOrValue<BigNumberish>,
       _random: PromiseOrValue<BigNumberish>,
@@ -730,11 +835,21 @@ export interface HybridComputeHelper extends BaseContract {
       overrides?: Overrides & { from?: PromiseOrValue<string> }
     ): Promise<PopulatedTransaction>;
 
+    Turing42(
+      overrides?: Overrides & { from?: PromiseOrValue<string> }
+    ): Promise<PopulatedTransaction>;
+
     TuringRandom(
       overrides?: Overrides & { from?: PromiseOrValue<string> }
     ): Promise<PopulatedTransaction>;
 
     TuringTx(
+      _url: PromiseOrValue<string>,
+      _payload: PromiseOrValue<BytesLike>,
+      overrides?: Overrides & { from?: PromiseOrValue<string> }
+    ): Promise<PopulatedTransaction>;
+
+    TuringTxV2(
       _url: PromiseOrValue<string>,
       _payload: PromiseOrValue<BytesLike>,
       overrides?: Overrides & { from?: PromiseOrValue<string> }

--- a/boba_community/hc-start/packages/contracts/gen/types/HybridComputeHelperFactory.ts
+++ b/boba_community/hc-start/packages/contracts/gen/types/HybridComputeHelperFactory.ts
@@ -106,27 +106,15 @@ export interface HybridComputeHelperFactoryInterface extends utils.Interface {
   ): Result;
 
   events: {
-    "OwnershipTransferred(address,address)": EventFragment;
     "HybridComputeHelperDeployed(address,address,uint256)": EventFragment;
+    "OwnershipTransferred(address,address)": EventFragment;
   };
 
-  getEvent(nameOrSignatureOrTopic: "OwnershipTransferred"): EventFragment;
   getEvent(
     nameOrSignatureOrTopic: "HybridComputeHelperDeployed"
   ): EventFragment;
+  getEvent(nameOrSignatureOrTopic: "OwnershipTransferred"): EventFragment;
 }
-
-export interface OwnershipTransferredEventObject {
-  previousOwner: string;
-  newOwner: string;
-}
-export type OwnershipTransferredEvent = TypedEvent<
-  [string, string],
-  OwnershipTransferredEventObject
->;
-
-export type OwnershipTransferredEventFilter =
-  TypedEventFilter<OwnershipTransferredEvent>;
 
 export interface HybridComputeHelperDeployedEventObject {
   owner: string;
@@ -140,6 +128,18 @@ export type HybridComputeHelperDeployedEvent = TypedEvent<
 
 export type HybridComputeHelperDeployedEventFilter =
   TypedEventFilter<HybridComputeHelperDeployedEvent>;
+
+export interface OwnershipTransferredEventObject {
+  previousOwner: string;
+  newOwner: string;
+}
+export type OwnershipTransferredEvent = TypedEvent<
+  [string, string],
+  OwnershipTransferredEventObject
+>;
+
+export type OwnershipTransferredEventFilter =
+  TypedEventFilter<OwnershipTransferredEvent>;
 
 export interface HybridComputeHelperFactory extends BaseContract {
   connect(signerOrProvider: Signer | Provider | string): this;
@@ -254,15 +254,6 @@ export interface HybridComputeHelperFactory extends BaseContract {
   };
 
   filters: {
-    "OwnershipTransferred(address,address)"(
-      previousOwner?: PromiseOrValue<string> | null,
-      newOwner?: PromiseOrValue<string> | null
-    ): OwnershipTransferredEventFilter;
-    OwnershipTransferred(
-      previousOwner?: PromiseOrValue<string> | null,
-      newOwner?: PromiseOrValue<string> | null
-    ): OwnershipTransferredEventFilter;
-
     "HybridComputeHelperDeployed(address,address,uint256)"(
       owner?: PromiseOrValue<string> | null,
       proxy?: null,
@@ -273,6 +264,15 @@ export interface HybridComputeHelperFactory extends BaseContract {
       proxy?: null,
       depositedBoba?: null
     ): HybridComputeHelperDeployedEventFilter;
+
+    "OwnershipTransferred(address,address)"(
+      previousOwner?: PromiseOrValue<string> | null,
+      newOwner?: PromiseOrValue<string> | null
+    ): OwnershipTransferredEventFilter;
+    OwnershipTransferred(
+      previousOwner?: PromiseOrValue<string> | null,
+      newOwner?: PromiseOrValue<string> | null
+    ): OwnershipTransferredEventFilter;
   };
 
   estimateGas: {

--- a/boba_community/hc-start/packages/contracts/gen/types/factories/HybridComputeHelperFactory__factory.ts
+++ b/boba_community/hc-start/packages/contracts/gen/types/factories/HybridComputeHelperFactory__factory.ts
@@ -37,31 +37,12 @@ const _abi = [
       {
         indexed: true,
         internalType: "address",
-        name: "previousOwner",
-        type: "address",
-      },
-      {
-        indexed: true,
-        internalType: "address",
-        name: "newOwner",
-        type: "address",
-      },
-    ],
-    name: "OwnershipTransferred",
-    type: "event",
-  },
-  {
-    anonymous: false,
-    inputs: [
-      {
-        indexed: true,
-        internalType: "address",
         name: "owner",
         type: "address",
       },
       {
         indexed: false,
-        internalType: "contract HybridComputeHelper",
+        internalType: "contract TuringHelper",
         name: "proxy",
         type: "address",
       },
@@ -73,6 +54,25 @@ const _abi = [
       },
     ],
     name: "HybridComputeHelperDeployed",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: "address",
+        name: "previousOwner",
+        type: "address",
+      },
+      {
+        indexed: true,
+        internalType: "address",
+        name: "newOwner",
+        type: "address",
+      },
+    ],
+    name: "OwnershipTransferred",
     type: "event",
   },
   {
@@ -117,7 +117,7 @@ const _abi = [
     name: "deployMinimal",
     outputs: [
       {
-        internalType: "contract HybridComputeHelper",
+        internalType: "contract TuringHelper",
         name: "",
         type: "address",
       },

--- a/boba_community/hc-start/packages/contracts/gen/types/factories/HybridComputeHelper__factory.ts
+++ b/boba_community/hc-start/packages/contracts/gen/types/factories/HybridComputeHelper__factory.ts
@@ -90,6 +90,25 @@ const _abi = [
         type: "uint256",
       },
     ],
+    name: "Offchain42",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: false,
+        internalType: "uint256",
+        name: "version",
+        type: "uint256",
+      },
+      {
+        indexed: false,
+        internalType: "uint256",
+        name: "random",
+        type: "uint256",
+      },
+    ],
     name: "OffchainRandom",
     type: "event",
   },
@@ -170,6 +189,30 @@ const _abi = [
         type: "uint256",
       },
     ],
+    name: "Get42",
+    outputs: [
+      {
+        internalType: "uint256",
+        name: "",
+        type: "uint256",
+      },
+    ],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "uint32",
+        name: "rType",
+        type: "uint32",
+      },
+      {
+        internalType: "uint256",
+        name: "_random",
+        type: "uint256",
+      },
+    ],
     name: "GetRandom",
     outputs: [
       {
@@ -212,6 +255,19 @@ const _abi = [
   },
   {
     inputs: [],
+    name: "Turing42",
+    outputs: [
+      {
+        internalType: "uint256",
+        name: "",
+        type: "uint256",
+      },
+    ],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [],
     name: "TuringRandom",
     outputs: [
       {
@@ -237,6 +293,30 @@ const _abi = [
       },
     ],
     name: "TuringTx",
+    outputs: [
+      {
+        internalType: "bytes",
+        name: "",
+        type: "bytes",
+      },
+    ],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "string",
+        name: "_url",
+        type: "string",
+      },
+      {
+        internalType: "bytes",
+        name: "_payload",
+        type: "bytes",
+      },
+    ],
+    name: "TuringTxV2",
     outputs: [
       {
         internalType: "bytes",

--- a/boba_community/hc-start/packages/contracts/src/abis/HybridComputeHelper.json
+++ b/boba_community/hc-start/packages/contracts/src/abis/HybridComputeHelper.json
@@ -1,406 +1,486 @@
- [
-    {
-      "anonymous": false,
-      "inputs": [
-        {
-          "indexed": false,
-          "internalType": "address",
-          "name": "_callerAddress",
-          "type": "address"
-        }
-      ],
-      "name": "AddPermittedCaller",
-      "type": "event"
-    },
-    {
-      "anonymous": false,
-      "inputs": [
-        {
-          "indexed": false,
-          "internalType": "address",
-          "name": "previousAdmin",
-          "type": "address"
-        },
-        {
-          "indexed": false,
-          "internalType": "address",
-          "name": "newAdmin",
-          "type": "address"
-        }
-      ],
-      "name": "AdminChanged",
-      "type": "event"
-    },
-    {
-      "anonymous": false,
-      "inputs": [
-        {
-          "indexed": true,
-          "internalType": "address",
-          "name": "beacon",
-          "type": "address"
-        }
-      ],
-      "name": "BeaconUpgraded",
-      "type": "event"
-    },
-    {
-      "anonymous": false,
-      "inputs": [
-        {
-          "indexed": false,
-          "internalType": "address",
-          "name": "_callerAddress",
-          "type": "address"
-        },
-        {
-          "indexed": false,
-          "internalType": "bool",
-          "name": "permitted",
-          "type": "bool"
-        }
-      ],
-      "name": "CheckPermittedCaller",
-      "type": "event"
-    },
-    {
-      "anonymous": false,
-      "inputs": [
-        {
-          "indexed": false,
-          "internalType": "uint256",
-          "name": "version",
-          "type": "uint256"
-        },
-        {
-          "indexed": false,
-          "internalType": "uint256",
-          "name": "random",
-          "type": "uint256"
-        }
-      ],
-      "name": "OffchainRandom",
-      "type": "event"
-    },
-    {
-      "anonymous": false,
-      "inputs": [
-        {
-          "indexed": false,
-          "internalType": "uint256",
-          "name": "version",
-          "type": "uint256"
-        },
-        {
-          "indexed": false,
-          "internalType": "bytes",
-          "name": "responseData",
-          "type": "bytes"
-        }
-      ],
-      "name": "OffchainResponse",
-      "type": "event"
-    },
-    {
-      "anonymous": false,
-      "inputs": [
-        {
-          "indexed": true,
-          "internalType": "address",
-          "name": "previousOwner",
-          "type": "address"
-        },
-        {
-          "indexed": true,
-          "internalType": "address",
-          "name": "newOwner",
-          "type": "address"
-        }
-      ],
-      "name": "OwnershipTransferred",
-      "type": "event"
-    },
-    {
-      "anonymous": false,
-      "inputs": [
-        {
-          "indexed": false,
-          "internalType": "address",
-          "name": "_callerAddress",
-          "type": "address"
-        }
-      ],
-      "name": "RemovePermittedCaller",
-      "type": "event"
-    },
-    {
-      "anonymous": false,
-      "inputs": [
-        {
-          "indexed": true,
-          "internalType": "address",
-          "name": "implementation",
-          "type": "address"
-        }
-      ],
-      "name": "Upgraded",
-      "type": "event"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "uint32",
-          "name": "rType",
-          "type": "uint32"
-        },
-        {
-          "internalType": "uint256",
-          "name": "_random",
-          "type": "uint256"
-        }
-      ],
-      "name": "GetRandom",
-      "outputs": [
-        {
-          "internalType": "uint256",
-          "name": "",
-          "type": "uint256"
-        }
-      ],
-      "stateMutability": "nonpayable",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "uint32",
-          "name": "rType",
-          "type": "uint32"
-        },
-        {
-          "internalType": "string",
-          "name": "_url",
-          "type": "string"
-        },
-        {
-          "internalType": "bytes",
-          "name": "_payload",
-          "type": "bytes"
-        }
-      ],
-      "name": "GetResponse",
-      "outputs": [
-        {
-          "internalType": "bytes",
-          "name": "",
-          "type": "bytes"
-        }
-      ],
-      "stateMutability": "nonpayable",
-      "type": "function"
-    },
-    {
-      "inputs": [],
-      "name": "TuringRandom",
-      "outputs": [
-        {
-          "internalType": "uint256",
-          "name": "",
-          "type": "uint256"
-        }
-      ],
-      "stateMutability": "nonpayable",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "string",
-          "name": "_url",
-          "type": "string"
-        },
-        {
-          "internalType": "bytes",
-          "name": "_payload",
-          "type": "bytes"
-        }
-      ],
-      "name": "TuringTx",
-      "outputs": [
-        {
-          "internalType": "bytes",
-          "name": "",
-          "type": "bytes"
-        }
-      ],
-      "stateMutability": "nonpayable",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "address",
-          "name": "_callerAddress",
-          "type": "address"
-        }
-      ],
-      "name": "addPermittedCaller",
-      "outputs": [],
-      "stateMutability": "nonpayable",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "address[]",
-          "name": "_callerAddresses",
-          "type": "address[]"
-        }
-      ],
-      "name": "addPermittedCallers",
-      "outputs": [],
-      "stateMutability": "nonpayable",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "address",
-          "name": "_callerAddress",
-          "type": "address"
-        }
-      ],
-      "name": "checkPermittedCaller",
-      "outputs": [
-        {
-          "internalType": "bool",
-          "name": "",
-          "type": "bool"
-        }
-      ],
-      "stateMutability": "nonpayable",
-      "type": "function"
-    },
-    {
-      "inputs": [],
-      "name": "initialize",
-      "outputs": [],
-      "stateMutability": "nonpayable",
-      "type": "function"
-    },
-    {
-      "inputs": [],
-      "name": "owner",
-      "outputs": [
-        {
-          "internalType": "address",
-          "name": "",
-          "type": "address"
-        }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "address",
-          "name": "",
-          "type": "address"
-        }
-      ],
-      "name": "permittedCaller",
-      "outputs": [
-        {
-          "internalType": "bool",
-          "name": "",
-          "type": "bool"
-        }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "address",
-          "name": "_callerAddress",
-          "type": "address"
-        }
-      ],
-      "name": "removePermittedCaller",
-      "outputs": [],
-      "stateMutability": "nonpayable",
-      "type": "function"
-    },
-    {
-      "inputs": [],
-      "name": "renounceOwnership",
-      "outputs": [],
-      "stateMutability": "nonpayable",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "bytes4",
-          "name": "_interfaceId",
-          "type": "bytes4"
-        }
-      ],
-      "name": "supportsInterface",
-      "outputs": [
-        {
-          "internalType": "bool",
-          "name": "",
-          "type": "bool"
-        }
-      ],
-      "stateMutability": "pure",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "address",
-          "name": "newOwner",
-          "type": "address"
-        }
-      ],
-      "name": "transferOwnership",
-      "outputs": [],
-      "stateMutability": "nonpayable",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "address",
-          "name": "newImplementation",
-          "type": "address"
-        }
-      ],
-      "name": "upgradeTo",
-      "outputs": [],
-      "stateMutability": "nonpayable",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "address",
-          "name": "newImplementation",
-          "type": "address"
-        },
-        {
-          "internalType": "bytes",
-          "name": "data",
-          "type": "bytes"
-        }
-      ],
-      "name": "upgradeToAndCall",
-      "outputs": [],
-      "stateMutability": "payable",
-      "type": "function"
-    }
-  ]
+[
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "_callerAddress",
+        "type": "address"
+      }
+    ],
+    "name": "AddPermittedCaller",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "previousAdmin",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "newAdmin",
+        "type": "address"
+      }
+    ],
+    "name": "AdminChanged",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "beacon",
+        "type": "address"
+      }
+    ],
+    "name": "BeaconUpgraded",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "_callerAddress",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "bool",
+        "name": "permitted",
+        "type": "bool"
+      }
+    ],
+    "name": "CheckPermittedCaller",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "version",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "random",
+        "type": "uint256"
+      }
+    ],
+    "name": "Offchain42",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "version",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "random",
+        "type": "uint256"
+      }
+    ],
+    "name": "OffchainRandom",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "version",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes",
+        "name": "responseData",
+        "type": "bytes"
+      }
+    ],
+    "name": "OffchainResponse",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "previousOwner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "OwnershipTransferred",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "_callerAddress",
+        "type": "address"
+      }
+    ],
+    "name": "RemovePermittedCaller",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "implementation",
+        "type": "address"
+      }
+    ],
+    "name": "Upgraded",
+    "type": "event"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint32",
+        "name": "rType",
+        "type": "uint32"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_random",
+        "type": "uint256"
+      }
+    ],
+    "name": "Get42",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint32",
+        "name": "rType",
+        "type": "uint32"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_random",
+        "type": "uint256"
+      }
+    ],
+    "name": "GetRandom",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint32",
+        "name": "rType",
+        "type": "uint32"
+      },
+      {
+        "internalType": "string",
+        "name": "_url",
+        "type": "string"
+      },
+      {
+        "internalType": "bytes",
+        "name": "_payload",
+        "type": "bytes"
+      }
+    ],
+    "name": "GetResponse",
+    "outputs": [
+      {
+        "internalType": "bytes",
+        "name": "",
+        "type": "bytes"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "Turing42",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "TuringRandom",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "string",
+        "name": "_url",
+        "type": "string"
+      },
+      {
+        "internalType": "bytes",
+        "name": "_payload",
+        "type": "bytes"
+      }
+    ],
+    "name": "TuringTx",
+    "outputs": [
+      {
+        "internalType": "bytes",
+        "name": "",
+        "type": "bytes"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "string",
+        "name": "_url",
+        "type": "string"
+      },
+      {
+        "internalType": "bytes",
+        "name": "_payload",
+        "type": "bytes"
+      }
+    ],
+    "name": "TuringTxV2",
+    "outputs": [
+      {
+        "internalType": "bytes",
+        "name": "",
+        "type": "bytes"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_callerAddress",
+        "type": "address"
+      }
+    ],
+    "name": "addPermittedCaller",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address[]",
+        "name": "_callerAddresses",
+        "type": "address[]"
+      }
+    ],
+    "name": "addPermittedCallers",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_callerAddress",
+        "type": "address"
+      }
+    ],
+    "name": "checkPermittedCaller",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "initialize",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "owner",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "permittedCaller",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_callerAddress",
+        "type": "address"
+      }
+    ],
+    "name": "removePermittedCaller",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "renounceOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes4",
+        "name": "_interfaceId",
+        "type": "bytes4"
+      }
+    ],
+    "name": "supportsInterface",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "pure",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "transferOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "newImplementation",
+        "type": "address"
+      }
+    ],
+    "name": "upgradeTo",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "newImplementation",
+        "type": "address"
+      },
+      {
+        "internalType": "bytes",
+        "name": "data",
+        "type": "bytes"
+      }
+    ],
+    "name": "upgradeToAndCall",
+    "outputs": [],
+    "stateMutability": "payable",
+    "type": "function"
+  }
+]

--- a/boba_community/hc-start/packages/contracts/src/abis/HybridComputeHelperFactory.json
+++ b/boba_community/hc-start/packages/contracts/src/abis/HybridComputeHelperFactory.json
@@ -26,31 +26,12 @@
       {
         "indexed": true,
         "internalType": "address",
-        "name": "previousOwner",
-        "type": "address"
-      },
-      {
-        "indexed": true,
-        "internalType": "address",
-        "name": "newOwner",
-        "type": "address"
-      }
-    ],
-    "name": "OwnershipTransferred",
-    "type": "event"
-  },
-  {
-    "anonymous": false,
-    "inputs": [
-      {
-        "indexed": true,
-        "internalType": "address",
         "name": "owner",
         "type": "address"
       },
       {
         "indexed": false,
-        "internalType": "contract HybridComputeHelper",
+        "internalType": "contract TuringHelper",
         "name": "proxy",
         "type": "address"
       },
@@ -62,6 +43,25 @@
       }
     ],
     "name": "HybridComputeHelperDeployed",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "previousOwner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "OwnershipTransferred",
     "type": "event"
   },
   {
@@ -106,7 +106,7 @@
     "name": "deployMinimal",
     "outputs": [
       {
-        "internalType": "contract HybridComputeHelper",
+        "internalType": "contract TuringHelper",
         "name": "",
         "type": "address"
       }

--- a/boba_community/hc-start/packages/contracts/src/addresses.ts
+++ b/boba_community/hc-start/packages/contracts/src/addresses.ts
@@ -1,8 +1,9 @@
 import { isTestEnv } from '@hc/react-app/src/utils/environment.utils'
 
 const addressesTestnet = {
-  HybridComputeHelper: '0xA00f82C6fe87E81ab3501A21c47227e84e3d9C48',
-  HybridComputeHelperFactory: '0x58dDFB37998584991d8b75F87baf0A3428dD095e',
+  // proxy at 0x701E03911e342Ca5Fa0950ce1680Af40e6171BA1
+  HybridComputeHelper: '0xBc8dd915c26F0e8A5416e0850450f2f0614f8617',
+  HybridComputeHelperFactory: '0xFeED2Dc24E3CCd9594B5122318F1b6c037492652',
   BobaToken: '0x4200000000000000000000000000000000000023',
 }
 

--- a/boba_community/hc-start/packages/dapp-contracts/README.md
+++ b/boba_community/hc-start/packages/dapp-contracts/README.md
@@ -1,0 +1,9 @@
+# Deployments
+
+## Goerli deployment
+- HybridComputeHelper: `0x701E03911e342Ca5Fa0950ce1680Af40e6171BA1`
+- HybridComputeHelper Implementation: `0xBc8dd915c26F0e8A5416e0850450f2f0614f8617`
+- HybridComputeHelperFactory: `0xFeED2Dc24E3CCd9594B5122318F1b6c037492652`
+
+- Multicall: `0x2576d6AB4B0A4e6CdCD939d5893330f7d0088245`
+- Multicall2: `0x20F00ff289595614386A7E70738b80bCBEeAbFE6`

--- a/boba_community/hc-start/packages/dapp-contracts/contracts/ITuringHelper.sol
+++ b/boba_community/hc-start/packages/dapp-contracts/contracts/ITuringHelper.sol
@@ -17,6 +17,7 @@ interface ITuringHelper {
        offchain interaction.
     */
     function TuringTx(string memory _url, bytes memory _payload) external returns (bytes memory);
+    function TuringTxV2(string memory _url, bytes memory _payload) external returns (bytes memory);
 
     function TuringRandom() external returns (uint256);
 }

--- a/boba_community/hc-start/packages/dapp-contracts/contracts/TuringHelper.sol
+++ b/boba_community/hc-start/packages/dapp-contracts/contracts/TuringHelper.sol
@@ -17,6 +17,7 @@ contract TuringHelper is ITuringHelper, OwnableUpgradeable, UUPSUpgradeable {
     event CheckPermittedCaller(address _callerAddress, bool permitted);
     event OffchainResponse(uint version, bytes responseData);
     event OffchainRandom(uint version, uint256 random);
+    event Offchain42(uint version, uint256 random);
 
     modifier onlyPermittedCaller() {
         require(
@@ -26,16 +27,23 @@ contract TuringHelper is ITuringHelper, OwnableUpgradeable, UUPSUpgradeable {
         _;
     }
 
+    /**
+    * @dev Part of the proxy/upgrade pattern.
+    */
+    function _authorizeUpgrade(address) internal override onlyOwner {}
+
+
     function initialize() initializer external {
         __Ownable_init();
         __UUPSUpgradeable_init();
         Self = TuringHelper(address(this));
     }
 
-    /**
-    * @dev Part of the proxy/upgrade pattern.
-    */
-    function _authorizeUpgrade(address) internal override onlyOwner {}
+    function addPermittedCaller(address _callerAddress)
+    public onlyOwner {
+        permittedCaller[_callerAddress] = true;
+        emit AddPermittedCaller(_callerAddress);
+    }
 
     /**
     * @dev Separations of concerns, convenience method for Factory
@@ -45,12 +53,6 @@ contract TuringHelper is ITuringHelper, OwnableUpgradeable, UUPSUpgradeable {
         for (uint i = 0; i < _callerAddresses.length; i++) {
             addPermittedCaller(_callerAddresses[i]);
         }
-    }
-
-    function addPermittedCaller(address _callerAddress)
-    public onlyOwner {
-        permittedCaller[_callerAddress] = true;
-        emit AddPermittedCaller(_callerAddress);
     }
 
     function removePermittedCaller(address _callerAddress)
@@ -68,18 +70,18 @@ contract TuringHelper is ITuringHelper, OwnableUpgradeable, UUPSUpgradeable {
 
     function GetErrorCode(uint32 rType)
     internal view returns (string memory) {
-        if (rType == 1) return "TURING: Geth intercept failure";
-        if (rType == 10) return "TURING: Incorrect input state";
-        if (rType == 11) return "TURING: Calldata too short";
-        if (rType == 12) return "TURING: URL >64 bytes";
-        if (rType == 13) return "TURING: Server error";
-        if (rType == 14) return "TURING: Could not decode server response";
-        if (rType == 15) return "TURING: Could not create rpc client";
-        if (rType == 16) return "TURING: RNG failure";
-        if (rType == 17) return "TURING: API Response >322 chars";
-        if (rType == 18) return "TURING: API Response >160 bytes";
-        if (rType == 19) return "TURING: Insufficient credit";
-        if (rType == 20) return "TURING: Missing cache entry";
+        if(rType ==  1) return "TURING: Geth intercept failure";
+        if(rType == 10) return "TURING: Incorrect input state";
+        if(rType == 11) return "TURING: Calldata too short";
+        if(rType == 12) return "TURING: URL >64 bytes";
+        if(rType == 13) return "TURING: Server error";
+        if(rType == 14) return "TURING: Could not decode server response";
+        if(rType == 15) return "TURING: Could not create rpc client";
+        if(rType == 16) return "TURING: RNG failure";
+        if(rType == 17) return "TURING: API Response >322 chars";
+        if(rType == 18) return "TURING: API Response >160 bytes";
+        if(rType == 19) return "TURING: Insufficient credit";
+        if(rType == 20) return "TURING: Missing cache entry";
     }
 
     /* This is the interface to the off-chain mechanism. Although
@@ -95,37 +97,51 @@ contract TuringHelper is ITuringHelper, OwnableUpgradeable, UUPSUpgradeable {
     function GetResponse(uint32 rType, string memory _url, bytes memory _payload)
     public returns (bytes memory) {
 
-        require(msg.sender == address(this), "Turing:GetResponse:msg.sender != address(this)");
-        require(_payload.length > 0, "Turing:GetResponse:no payload");
-        require(rType == 2, string(GetErrorCode(rType)));
-        // l2geth can pass values here to provide debug information
+        require (msg.sender == address(this), "Turing:GetResponse:msg.sender != address(this)");
+        require (_payload.length > 0, "Turing:GetResponse:no payload");
+        require ((rType & 0x00ffffff) == 2, string(GetErrorCode(rType))); // l2geth can pass values here to provide debug information
         return _payload;
     }
 
     function GetRandom(uint32 rType, uint256 _random)
     public returns (uint256) {
 
-        require(msg.sender == address(this), "Turing:GetResponse:msg.sender != address(this)");
-        require(rType == 2, string(GetErrorCode(rType)));
+        require (msg.sender == address(this), "Turing:GetResponse:msg.sender != address(this)");
+        require (rType == 2, string(GetErrorCode(rType)));
+        return _random;
+    }
+
+    function Get42(uint32 rType, uint256 _random)
+    public returns (uint256) {
+
+        require (msg.sender == address(this), "Turing:GetResponse:msg.sender != address(this)");
+        require (rType == 2, string(GetErrorCode(rType)));
         return _random;
     }
 
     /* Called from the external contract. It takes an api endponit URL
-       and an abi-encoded request payload. The URL and the list of allowed
-       methods are supplied when the contract is created. In the future
-       some of this registration might be moved into l2geth, allowing for
-       security measures such as TLS client certificates. A configurable timeout
-       could also be added.
+       and an abi-encoded request payload.
+    */
+    function TuringTxV2(string memory _url, bytes memory _payload)
+    public onlyPermittedCaller override returns (bytes memory) {
+        require (_payload.length > 0, "Turing:TuringTx:no payload");
 
-       Logs the offchain response so that a future verifier or fraud prover
-       can replay the transaction and ensure that it results in the same state
-       root as during the initial execution. Note - a future version might
-       need to include a timestamp and/or more details about the
-       offchain interaction.
+        /* Initiate the request. This can't be a local function call
+           because that would stay inside the EVM and not give l2geth
+           a place to intercept and re-write the call.
+        */
+
+        bytes memory response = Self.GetResponse(0x02000001, _url, _payload);
+        emit OffchainResponse(0x01, response);
+        return response;
+    }
+
+    /* Legacy version which includes a Length prefix on the off-chain
+       request and response. For new development, use TuringTxV2
     */
     function TuringTx(string memory _url, bytes memory _payload)
     public onlyPermittedCaller override returns (bytes memory) {
-        require(_payload.length > 0, "Turing:TuringTx:no payload");
+        require (_payload.length > 0, "Turing:TuringTx:no payload");
 
         /* Initiate the request. This can't be a local function call
            because that would stay inside the EVM and not give l2geth
@@ -144,10 +160,17 @@ contract TuringHelper is ITuringHelper, OwnableUpgradeable, UUPSUpgradeable {
         return response;
     }
 
+    function Turing42()
+    public onlyPermittedCaller returns (uint256) {
+
+        uint256 response = Self.Get42(2, 42);
+        emit Offchain42(0x01, response);
+        return response;
+    }
+
     // ERC165 check interface
     function supportsInterface(bytes4 _interfaceId) public pure returns (bool) {
-        bytes4 firstSupportedInterface = bytes4(keccak256("supportsInterface(bytes4)"));
-        // ERC165
+        bytes4 firstSupportedInterface = bytes4(keccak256("supportsInterface(bytes4)")); // ERC165
         bytes4 secondSupportedInterface = ITuringHelper.TuringTx.selector;
         return _interfaceId == firstSupportedInterface || _interfaceId == secondSupportedInterface;
     }

--- a/boba_community/hc-start/packages/dapp-contracts/env.example
+++ b/boba_community/hc-start/packages/dapp-contracts/env.example
@@ -1,0 +1,1 @@
+PRIVATE_KEY=

--- a/boba_community/hc-start/packages/dapp-contracts/hardhat.config.ts
+++ b/boba_community/hc-start/packages/dapp-contracts/hardhat.config.ts
@@ -13,13 +13,13 @@ const config: HardhatUserConfig = {
     boba_local: {
       url: 'http://localhost:8545',
       accounts: [
-        process.env.LOCAL_PRIVATE_KEY,
-        process.env.LOCAL_PRIVATE_KEY_2,
+        process.env.LOCAL_PRIVATE_KEY ?? '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80',
+        process.env.LOCAL_PRIVATE_KEY_2 ?? '0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d',
       ],
     },
     boba_goerli: {
       url: 'https://goerli.boba.network',
-      accounts: [process.env.PRIVATE_KEY, process.env.PRIVATE_KEY_2],
+      accounts: process.env.PRIVATE_KEY ? [process.env.PRIVATE_KEY] : [],
     },
     boba_mainnet: {
       url: 'https://mainnet.boba.network',

--- a/boba_community/hc-start/packages/dapp-contracts/scripts/deploy-factory.ts
+++ b/boba_community/hc-start/packages/dapp-contracts/scripts/deploy-factory.ts
@@ -1,6 +1,6 @@
 import hre, { upgrades } from 'hardhat'
 import { Contract, ContractFactory, providers, Wallet } from 'ethers'
-import HybridComputeHelperJson from '../artifacts/contracts/HybridComputeHelper.sol/HybridComputeHelper.json'
+import HybridComputeHelperJson from '../artifacts/contracts/TuringHelper.sol/TuringHelper.json'
 import HybridComputeHelperFactoryJson from '../artifacts/contracts/HybridComputeHelperFactory.sol/HybridComputeHelperFactory.json'
 const cfg = hre.network.config
 
@@ -37,22 +37,15 @@ async function main() {
 
   let BOBAL2Address
   let BobaTuringCreditAddress
-  let WETH
-  let Router
-  if (hre.network.name === 'boba_rinkeby') {
-    BOBAL2Address = '0xF5B97a4860c1D81A1e915C40EcCB5E4a5E6b8309'
-    BobaTuringCreditAddress = '0x208c3CE906cd85362bd29467819d3AcbE5FC1614'
-    WETH = '0xDeadDeAddeAddEAddeadDEaDDEAdDeaDDeAD0000'
-    Router = '0x4df04E20cCd9a8B82634754fcB041e86c5FF085A'
+  if (hre.network.name === 'boba_goerli') {
+    BOBAL2Address = '0x4200000000000000000000000000000000000023'
+    BobaTuringCreditAddress = '0x4200000000000000000000000000000000000020'
   } else if (hre.network.name === 'boba_mainnet') {
     BOBAL2Address = '0xa18bF3994C0Cc6E3b63ac420308E5383f53120D7'
     BobaTuringCreditAddress = '0xF8D2f1b0292C0Eeef80D8F47661A9DaCDB4b23bf'
-    WETH = '0xDeadDeAddeAddEAddeadDEaDDEAdDeaDDeAD0000'
-    Router = '0x17C83E2B96ACfb5190d63F5E46d93c107eC0b514'
   }
 
   const HybridComputeHelperFactory = await Factory__HybridComputeHelperFactory.deploy(
-    Router, WETH,
     BOBAL2Address,
     implementationHybridComputeHelper,
     BobaTuringCreditAddress

--- a/boba_community/hc-start/packages/dapp-contracts/test/factory.ts
+++ b/boba_community/hc-start/packages/dapp-contracts/test/factory.ts
@@ -65,7 +65,7 @@ describe('Turing Helper Factory', function () {
       BobaTuringCreditAddress = '0xF8D2f1b0292C0Eeef80D8F47661A9DaCDB4b23bf'
       WETHAddress = '0xDeadDeAddeAddEAddeadDEaDDEAdDeaDDeAD0000'
       RouterAddress = '0x17C83E2B96ACfb5190d63F5E46d93c107eC0b514'
-    } else if (hre.network.name === 'rinkeby') {
+    } else if (hre.network.name === 'goerli') {
       WETHAddress = '0xc778417e063141139fce010982780140aa0cd5ab'
       RouterAddress = '0x6000eb83c2583AFD25D93cB0629D6b0a0B2F245c'
     } else {
@@ -134,27 +134,11 @@ describe('Turing Helper Factory', function () {
     console.log('    Factory contract deployed as', hcFactory.address)
   })
 
-  /*it.only('should deploy new funded HybridComputeHelper via Factory (payment in ETH)', async () => {
-    const minAmountBoba = parseEther('0.02')
-
-    const implTx = await turingFactory.deployMinimalETH(
-      [deployerWallet.address],
-      minAmountBoba,
-      { ...gasOverride, value: ethers.utils.parseEther('0.1') }
-    )
-
-    // TODO: Check if rest ETH is refunded
-
-    const res = await implTx.wait()
-    console.log('TX confirmation: ', res)
-    expect(res).to.be.ok
-  })*/
-
   let newHybridComputeHelper: Contract
   let newHybridComputeHelperOtherWallet: Contract
   it('should deploy new funded HybridComputeHelper via Factory and have proper ownership (payment in BOBA)', async () => {
     // Approva Boba before
-    const bobaToDeposit = ethers.utils.parseEther('0.02')
+    const bobaToDeposit = ethers.utils.parseEther('0.2')
     const approveTx = await L2BOBAToken.approve(
       hcFactory.address,
       bobaToDeposit

--- a/boba_community/hc-start/packages/react-app/package.json
+++ b/boba_community/hc-start/packages/react-app/package.json
@@ -25,12 +25,12 @@
     "@fortawesome/free-regular-svg-icons": "^6.1.1",
     "@fortawesome/free-solid-svg-icons": "^6.1.1",
     "@fortawesome/react-fontawesome": "^0.1.18",
+    "@hc/contracts": "^1.0.0",
     "@mui/material": "^5.6.1",
     "@testing-library/dom": "^8.13.0",
     "@testing-library/jest-dom": "^5.16.4",
     "@testing-library/react": "^12.1.5",
     "@testing-library/user-event": "^14.1.0",
-    "@hc/contracts": "^1.0.0",
     "@uiw/react-textarea-code-editor": "^2.0.1",
     "@usedapp/core": "^0.12.9",
     "babel-plugin-macros": "^3.1.0",
@@ -51,10 +51,10 @@
     ]
   },
   "scripts": {
-    "build": "react-scripts build",
+    "build": "GENERATE_SOURCEMAP=false react-scripts build",
     "eject": "react-scripts eject",
     "ipfs": "yarn build && ipfs-deploy build/",
-    "start": "react-scripts start",
+    "start": "GENERATE_SOURCEMAP=false react-scripts start",
     "test": "react-scripts test"
   },
   "devDependencies": {

--- a/boba_community/hc-start/packages/react-app/public/index.html
+++ b/boba_community/hc-start/packages/react-app/public/index.html
@@ -2,19 +2,19 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
+    <link rel="icon" href="./favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />
     <meta
       name="description"
-      content="Turing Starter App - Use Turing with ease"
+      content="HybridCompute Starter App - Use HybridCompute with ease"
     />
-    <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
+    <link rel="apple-touch-icon" href="./logo192.png" />
     <!--
       manifest.json provides metadata used when your web app is installed on a
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
     -->
-    <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
+    <link rel="manifest" href="./manifest.json" />
     <!--
       Notice the use of %PUBLIC_URL% in the tags above.
       It will be replaced with the URL of the `public` folder during the build.

--- a/boba_community/hc-start/packages/react-app/public/manifest.json
+++ b/boba_community/hc-start/packages/react-app/public/manifest.json
@@ -1,6 +1,6 @@
 {
-  "short_name": "Turing Starter",
-  "name": "Turing Starter - Use Turing with ease",
+  "short_name": "HybridCompute Starter",
+  "name": "HybridCompute Starter - Use HybridCompute with ease",
   "icons": [
     {
       "src": "favicon.ico",

--- a/boba_community/hc-start/packages/react-app/src/components/WalletButton.tsx
+++ b/boba_community/hc-start/packages/react-app/src/components/WalletButton.tsx
@@ -34,7 +34,7 @@ const switchNetwork = async (chainConfig, chainName: string) => {
               chainId: `0x${chainConfig.readOnlyChainId.toString(16)}`,
               nativeCurrency: { name: "ETH", decimals: 18, symbol: "ETH" },
               rpcUrls: [
-                `https://${isTestEnv() ? "rinkeby" : "mainnet"}.boba.network`
+                `https://${isTestEnv() ? "goerli" : "mainnet"}.boba.network`
               ]
             }
           ]
@@ -70,7 +70,7 @@ export function WalletButton(props: IWalletButtonProps) {
   }, [error]);
 
   const isTestnet = isTestEnv();
-  const chainName = `Boba ${isTestnet ? "Rinkeby" : "Mainnet"}`;
+  const chainName = `Boba ${isTestnet ? "Testnet" : "Mainnet"}`;
   const chainConfig = getChainConfig();
 
   return <Stack direction="row" spacing={2} justifyContent="right" alignItems="center" marginRight={6}>
@@ -80,7 +80,7 @@ export function WalletButton(props: IWalletButtonProps) {
                 style={{borderTopRightRadius: 0, borderBottomRightRadius: 0, borderRight: 0}}
                 target="_blank"
                 href={isTestnet
-                  ? "https://gateway.rinkeby.boba.network/"
+                  ? "https://gateway.boba.network/"
                   : `https://oolongswap.com/#/swap?outputCurrency=${props.contractBobaToken.address}`}>
           {bobaTokenBalance.lte(0)
             ? <><FontAwesomeIcon bounce={true} icon={regular("credit-card")} />&nbsp;Get</>

--- a/boba_community/hc-start/packages/react-app/src/components/steps/step-implement-aws-lambda.tsx
+++ b/boba_community/hc-start/packages/react-app/src/components/steps/step-implement-aws-lambda.tsx
@@ -16,7 +16,7 @@ export const StepImplementAWSLambda = () => {
       padding={15}
       style={{
         fontSize: 12,
-        backgroundColor: "#333",
+        backgroundColor: "#ccc",
         fontFamily: "ui-monospace,SFMono-Regular,SF Mono,Consolas,Liberation Mono,Menlo,monospace"
       }}
     />;

--- a/boba_community/hc-start/packages/react-app/src/constants/network.constants.ts
+++ b/boba_community/hc-start/packages/react-app/src/constants/network.constants.ts
@@ -8,8 +8,8 @@ const BobaMainnetChain: Chain = {
   isLocalChain: false,
   multicallAddress: '0xC5042a76652770d696Cc434026C971fd4DDD27b9',
   multicall2Address: '0xaD652645014b6d8Ef023d62aF144aAefA08CeCa5',
-  getExplorerAddressLink: (address: string) => `https://blockexplorer.boba.network/address/${address}`,
-  getExplorerTransactionLink: (transactionHash: string) => `https://blockexplorer.boba.network/tx/${transactionHash}`,
+  getExplorerAddressLink: (address: string) => `https://bobascan.com/address/${address}`,
+  getExplorerTransactionLink: (transactionHash: string) => `https://bobascan.com/tx/${transactionHash}`,
 }
 
 const BobaGoerliChain: Chain = {
@@ -17,8 +17,8 @@ const BobaGoerliChain: Chain = {
   chainName: 'Boba Goerli',
   isTestChain: true,
   isLocalChain: false,
-  multicallAddress: '0x2D7a14384f4BeB2EDc33Ca4B43ea8028d1155E05',
-  multicall2Address: '0x3CA4f8c5730526aAE8F5e8F475af60EA2Ae6b9E0',
+  multicallAddress: '0x2576d6AB4B0A4e6CdCD939d5893330f7d0088245',
+  multicall2Address: '0x20F00ff289595614386A7E70738b80bCBEeAbFE6',
   getExplorerAddressLink: (address: string) => `https://testnet.bobascan.com/address/${address}`,
   getExplorerTransactionLink: (transactionHash: string) => `https://testnet.bobascan.com/tx/${transactionHash}`,
 }

--- a/boba_community/hc-start/packages/react-app/src/graphql/subgraph-client.ts
+++ b/boba_community/hc-start/packages/react-app/src/graphql/subgraph-client.ts
@@ -4,6 +4,6 @@ import { isTestEnv } from "../utils/environment.utils";
 // TODO: Just use the existing subgraph and add TuringFactory on there
 export const subgraphClient = new ApolloClient({
   cache: new InMemoryCache(),
-  uri: isTestEnv() ? 'https://graph.rinkeby.boba.network:8000/subgraphs/name/boba/Bridges'
+  uri: isTestEnv() ? 'https://graph.goerli.boba.network:8000/subgraphs/name/boba/Bridges'
     : "https://thegraph.com/hosted-service/subgraph/bobanetwork/boba-l2-subgraph"
 });

--- a/boba_community/hc-start/packages/react-app/src/utils/environment.utils.ts
+++ b/boba_community/hc-start/packages/react-app/src/utils/environment.utils.ts
@@ -1,4 +1,4 @@
 
 export const isTestEnv = (): boolean => JSON.parse(process.env.REACT_APP_USE_TESTNET ?? 'true')
 
-export const getBlockExplorerBaseURL = () => `https://blockexplorer${isTestEnv() ? '.rinkeby' : ''}.boba.network`
+export const getBlockExplorerBaseURL = () => `https://${isTestEnv() ? 'testnet' : ''}.bobascan.com`

--- a/boba_community/hc-start/packages/react-app/yarn.lock
+++ b/boba_community/hc-start/packages/react-app/yarn.lock
@@ -4461,9 +4461,9 @@ caniuse-api@^3.0.0:
     lodash.uniq "^4.5.0"
 
 caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001317:
-  version "1.0.30001331"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001331.tgz#41048f2a5cf0c3c6198f40207cd323388b3d4399"
-  integrity sha512-Y1xk6paHpUXKP/P6YjQv1xqyTbgAP05ycHBcRdQjTcyXlWol868sJJPlmk5ylOekw2BrucWes5jk+LvVd7WZ5Q==
+  version "1.0.30001495"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001495.tgz"
+  integrity sha512-F6x5IEuigtUfU5ZMQK2jsy5JqUUlEFRVZq8bO2a+ysq5K7jD6PPc9YXZj78xDNS3uNchesp1Jw47YXEqr+Viyg==
 
 case-sensitive-paths-webpack-plugin@^2.4.0:
   version "2.4.0"

--- a/boba_community/hc-start/yarn.lock
+++ b/boba_community/hc-start/yarn.lock
@@ -1825,6 +1825,13 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
+"@cspotcode/source-map-support@^0.8.0":
+  version "0.8.1"
+  resolved "https://registry.yarnpkg.com/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz#00629c35a688e05a88b1cda684fb9d5e73f000a1"
+  integrity sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==
+  dependencies:
+    "@jridgewell/trace-mapping" "0.3.9"
+
 "@csstools/normalize.css@*":
   version "12.0.0"
   resolved "https://registry.yarnpkg.com/@csstools/normalize.css/-/normalize.css-12.0.0.tgz#a9583a75c3f150667771f30b60d9f059473e62c4"
@@ -2992,6 +2999,11 @@
   resolved "https://registry.yarnpkg.com/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz#2203b118c157721addfe69d47b70465463066d78"
   integrity sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==
 
+"@jridgewell/resolve-uri@^3.0.3":
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/@jridgewell/resolve-uri/-/resolve-uri-3.1.1.tgz#c08679063f279615a3326583ba3a90d1d82cc721"
+  integrity sha512-dSYZh7HhCDtCKm4QakX0xFpsRDqjjtZf/kjI/v3T3Nwt5r8/qz/M19F9ySyOqU94SXBmeG9ttTul+YnR4LOxFA==
+
 "@jridgewell/set-array@^1.0.0", "@jridgewell/set-array@^1.0.1":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@jridgewell/set-array/-/set-array-1.1.2.tgz#7c6cf998d6d20b914c0a55a91ae928ff25965e72"
@@ -3009,6 +3021,14 @@
   version "1.4.14"
   resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz#add4c98d341472a289190b424efbdb096991bb24"
   integrity sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==
+
+"@jridgewell/trace-mapping@0.3.9":
+  version "0.3.9"
+  resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz#6534fd5933a53ba7cbf3a17615e273a0d1273ff9"
+  integrity sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==
+  dependencies:
+    "@jridgewell/resolve-uri" "^3.0.3"
+    "@jridgewell/sourcemap-codec" "^1.4.10"
 
 "@jridgewell/trace-mapping@^0.3.14", "@jridgewell/trace-mapping@^0.3.9":
   version "0.3.17"
@@ -3871,6 +3891,26 @@
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/@trysound/sax/-/sax-0.2.0.tgz#cccaab758af56761eb7bf37af6f03f326dd798ad"
   integrity sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA==
+
+"@tsconfig/node10@^1.0.7":
+  version "1.0.9"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node10/-/node10-1.0.9.tgz#df4907fc07a886922637b15e02d4cebc4c0021b2"
+  integrity sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA==
+
+"@tsconfig/node12@^1.0.7":
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node12/-/node12-1.0.11.tgz#ee3def1f27d9ed66dac6e46a295cffb0152e058d"
+  integrity sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==
+
+"@tsconfig/node14@^1.0.0":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node14/-/node14-1.0.3.tgz#e4386316284f00b98435bf40f72f75a09dabf6c1"
+  integrity sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==
+
+"@tsconfig/node16@^1.0.2":
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node16/-/node16-1.0.4.tgz#0b92dcc0cc1c81f6f306a381f28e31b1a56536e9"
+  integrity sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==
 
 "@typechain/ethers-v5@^10.0.0":
   version "10.1.1"
@@ -4806,6 +4846,11 @@ acorn-walk@^7.0.0, acorn-walk@^7.1.1:
   resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-7.2.0.tgz#0de889a601203909b0fbe07b8938dc21d2e967bc"
   integrity sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==
 
+acorn-walk@^8.1.1:
+  version "8.2.0"
+  resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-8.2.0.tgz#741210f2e2426454508853a2f44d0ab83b7f69c1"
+  integrity sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==
+
 acorn@^7.0.0, acorn@^7.1.1:
   version "7.4.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.4.1.tgz#feaed255973d2e77555b83dbc08851a6c63520fa"
@@ -4815,6 +4860,11 @@ acorn@^8.2.4, acorn@^8.5.0, acorn@^8.7.1, acorn@^8.8.0:
   version "8.8.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.8.1.tgz#0a3f9cbecc4ec3bea6f0a80b66ae8dd2da250b73"
   integrity sha512-7zFpHzhnqYKrkYdUjF1HI1bzd0VygEGX8lFk4k5zVMqHEoES+P+7TKI+EvLO9WVMJ8eekdO0aDEK044xTXwPPA==
+
+acorn@^8.4.1:
+  version "8.8.2"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.8.2.tgz#1b2f25db02af965399b9776b0c2c391276d37c4a"
+  integrity sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==
 
 address@^1.0.1, address@^1.1.2:
   version "1.2.1"
@@ -9010,7 +9060,7 @@ ethereumjs-wallet@0.6.5:
     utf8 "^3.0.0"
     uuid "^3.3.2"
 
-ethers@^5.0.1, ethers@^5.0.2, ethers@^5.5.2, ethers@^5.5.4, ethers@^5.6.2:
+ethers@^5.0.1, ethers@^5.0.2, ethers@^5.5.2, ethers@^5.5.4:
   version "5.7.2"
   resolved "https://registry.yarnpkg.com/ethers/-/ethers-5.7.2.tgz#3a7deeabbb8c030d4126b24f84e525466145872e"
   integrity sha512-wswUsmWo1aOK8rR7DIKiWSw9DbLWe6x98Jrn8wcTflTVvaXhAMaB5zGAXy0GYQEQp9iO1iSHWVyARQm11zUtyg==
@@ -16567,7 +16617,7 @@ source-map-support@^0.4.15:
   dependencies:
     source-map "^0.5.6"
 
-source-map-support@^0.5.13, source-map-support@^0.5.17, source-map-support@^0.5.6, source-map-support@~0.5.20:
+source-map-support@^0.5.13, source-map-support@^0.5.6, source-map-support@~0.5.20:
   version "0.5.21"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.21.tgz#04fe7c7f9e1ed2d662233c28cb2b35b9f63f6e4f"
   integrity sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==
@@ -17518,16 +17568,23 @@ ts-invariant@^0.10.3:
   dependencies:
     tslib "^2.1.0"
 
-ts-node@^9.1.1:
-  version "9.1.1"
-  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-9.1.1.tgz#51a9a450a3e959401bda5f004a72d54b936d376d"
-  integrity sha512-hPlt7ZACERQGf03M253ytLY3dHbGNGrAq9qIHWUY9XHYl1z7wYngSr3OQ5xmui8o2AaxsONxIzjafLUiWBo1Fg==
+ts-node@10.9.1:
+  version "10.9.1"
+  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-10.9.1.tgz#e73de9102958af9e1f0b168a6ff320e25adcff4b"
+  integrity sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==
   dependencies:
+    "@cspotcode/source-map-support" "^0.8.0"
+    "@tsconfig/node10" "^1.0.7"
+    "@tsconfig/node12" "^1.0.7"
+    "@tsconfig/node14" "^1.0.0"
+    "@tsconfig/node16" "^1.0.2"
+    acorn "^8.4.1"
+    acorn-walk "^8.1.1"
     arg "^4.1.0"
     create-require "^1.1.0"
     diff "^4.0.1"
     make-error "^1.1.1"
-    source-map-support "^0.5.17"
+    v8-compile-cache-lib "^3.0.1"
     yn "3.1.1"
 
 tsconfig-paths@^3.14.1:
@@ -17697,10 +17754,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==
 
-typescript@^4.2.3, typescript@^4.6.3:
-  version "4.9.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.3.tgz#3aea307c1746b8c384435d8ac36b8a2e580d85db"
-  integrity sha512-CIfGzTelbKNEnLpLdGFgdyKhG23CKdKgQPOBc+OUNrkJ2vr+KSzsSV5kq5iWhEQbok+quxgGzrAtGWCyU7tHnA==
+typescript@^4.3.5:
+  version "4.9.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.5.tgz#095979f9bcc0d09da324d58d03ce8f8374cbe65a"
+  integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==
 
 typewise-core@^1.2, typewise-core@^1.2.0:
   version "1.2.0"
@@ -18060,6 +18117,11 @@ uuid@^9.0.0:
   version "9.0.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-9.0.0.tgz#592f550650024a38ceb0c562f2f6aa435761efb5"
   integrity sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==
+
+v8-compile-cache-lib@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz#6336e8d71965cb3d35a1bbb7868445a7c05264bf"
+  integrity sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==
 
 v8-to-istanbul@^8.1.0:
   version "8.1.1"

--- a/packages/boba/register/addresses/addressesGoerli_0x6FF9c8FF8F0B6a0763a3030540c21aFC721A9148.json
+++ b/packages/boba/register/addresses/addressesGoerli_0x6FF9c8FF8F0B6a0763a3030540c21aFC721A9148.json
@@ -69,5 +69,6 @@
   "AggregatorHCHepler": "0x45c5dB3F5AC1579DD43404e47562641b61A6AC77",
   "Proxy__ETHUSD_AggregatorHC": "0x9e28dE704435871af476460B456Ec741fE5DE24f",
   "ETHUSD_AggregatorHC": "0x300f35972189d5FbEe140E552Dac80df85E6521C",
-  "L2StandardTokenFactory": "0xD2ae16D8c66ac7bc1Cf3c9e5d6bfE5f76BeDb826"
+  "L2StandardTokenFactory": "0xD2ae16D8c66ac7bc1Cf3c9e5d6bfE5f76BeDb826",
+  "HybridComputeHelperFactory": "0xFeED2Dc24E3CCd9594B5122318F1b6c037492652"
 }


### PR DESCRIPTION
:clipboard:  part of https://github.com/bobanetwork/boba-aws-infrastructure/issues/40

## Overview

HybridCompute starter was down for both mainnet and goerli due to our AWS reorganization. 
Mainnet was still up somewhere, while testnet got wiped completely. 

## Changes

- Fresh redeployment of contracts to now also support TuringV2 etc. 
- Goerli adaptations in frontend
- Deployment of Goerli frontend outstanding (already uploaded prod version to a S3 bucket in ethereum-testnet), DNS outstanding

## Testing

Integration tests of Contracts run successfully & manual test via DApp succeeded as well, except of: 
https://github.com/bobanetwork/boba/issues/910
