### PR TITLE
Remove Boba Goerli from Graph docs

### DIFF
--- a/for-developers/features/subgraph.md
+++ b/for-developers/features/subgraph.md
@@ -17,7 +17,7 @@ yarn global add --dev @graphprotocol/graph-ts
 
 <figure><img src="../../../.gitbook/assets/Artboard 2 (1) (1).png" alt=""><figcaption></figcaption></figure>
 
-First, `cd` to either the **L1** or the **L2** folders, depending on where you will be deploying your subgraphs to. There are four subgraphs: Ethereum, Boba, Rinkeby, and Boba-Rinkeby. A deploy key or access token is required to deploy subgraphs. Depending on which chain you are indexing, provide either `mainnet` or `rinkeby` as a setting to `yarn prepare:`.
+First, `cd` to either the **L1** or the **L2** folders, depending on where you will be deploying your subgraphs to. There are three subgraphs: Ethereum, Boba, and Goerli. A deploy key or access token is required to deploy subgraphs. Depending on which chain you are indexing, provide either `mainnet` or `goerli` as a setting to `yarn prepare:`.
 
 ### L1 Subgraphs
 
@@ -28,12 +28,12 @@ graph auth --product hosted-service <ACCESS_TOKEN>
 # or, graph auth --studio $DEPLOY_KEY
 cd L1
 yarn install
-yarn prepare:mainnet 
-# or, yarn prepare:rinkeby
+yarn prepare:mainnet
+# or, yarn prepare:goerli
 yarn codegen
 yarn build
-graph deploy --product hosted-service BOBANETWORK/boba-l2-subgraph 
-# or, graph deploy --studio boba-network-rinkeby
+graph deploy --product hosted-service BOBANETWORK/boba-l2-subgraph
+# or, graph deploy --studio boba-network-goerli
 ```
 
 ### L2 Subgraphs
@@ -46,11 +46,10 @@ graph auth --product hosted-service <ACCESS_TOKEN>
 cd L2
 yarn install
 yarn prepare:mainnet
-# or, yarn prepare:rinkeby
 yarn codegen
 yarn build
 graph deploy --product hosted-service BOBANETWORK/boba-l2-subgraph
-# or, yarn deploy:subgraph:rinkeby
+# No graph on Boba Goerli available
 ```
 
 _NOTE: When you log into https://thegraph.com/hosted-service/dashboard, you may have more than one account. Make sure that you are using the ACCESS\_TOKEN associated with the correct account, otherwise your depoyment will fail. You can cycle through your multiple accounts by clicking on your GitHub user ID or whatever other account is displayed next to your user Avatar._
@@ -70,25 +69,8 @@ Here is some example queries to get you started:
     https://api.thegraph.com/subgraphs/name/bobanetwork/boba-l2-subgraph
 ```
 
-```bash
-# L2 Boba Rinkeby Query
-
-  curl -g -X POST \
-    -H "Content-Type: application/json" \
-    -d '{"query":"{ governorProposalCreateds {proposalId values description proposer}}"}' \
-    https://graph.rinkeby.boba.network/subgraphs/name/boba/Bridges
-```
-
-
 
 <figure><img src="../../../.gitbook/assets/Artboard 4 (12).png" alt=""><figcaption></figcaption></figure>
 
 * The Mainnet Graph Node is hosted by **The Graph**. Visit https://thegraph.com/hosted-service/ to deploy your subgraphs. You can experiment here: [bobanetwork/boba-l2-subgraph](https://thegraph.com/hosted-service/subgraph/bobanetwork/boba-l2-subgraph?query=Example%20query).
-* Rinkeby endpoint: https://graph.rinkeby.boba.network. You can experiment here: [boba/Bridges/graphql](https://graph.rinkeby.boba.network/subgraphs/name/boba/Bridges/graphql)
-
-| **Port** | **Purpose**                                   | **Routes**              | URL                                                                                  | **Permission** |
-| -------- | --------------------------------------------- | ----------------------- | ------------------------------------------------------------------------------------ | -------------- |
-| 8000     | GraphQL HTTP server                           | /subgraphs/name/.../... | <p>https://graph.rinkeby.boba.network<br>https://graph.rinkeby.boba.network:8000</p> | Public         |
-| 8020     | <p>JSON-RPC<br>(for managing deployments)</p> | /                       | https://graph.rinkeby.boba.network:8020                                              | Private        |
-| 8030     | Subgraph indexing status API                  | /graphql                | https://graph.rinkeby.boba.network:8030                                              | Public         |
-| 8040     | Prometheus metrics                            | /metrics                | https://graph.rinkeby.boba.network:8040                                              | Public         |
+* No testnet graph node available.


### PR DESCRIPTION
:clipboard: Resolves #910 

## Overview

We don't have a graph endpoint for Boba Goerli and don't plan to offer one. 

## Changes

- Remove Boba Goerli graph cues. 

## Testing

