### PR TITLE
gcc might not be needed

### DIFF
--- a/boba_community/fraud-detector/docker/Dockerfile.fraud-detector
+++ b/boba_community/fraud-detector/docker/Dockerfile.fraud-detector
@@ -1,7 +1,4 @@
 FROM python:3.8-slim
-RUN apt-get update \
-  && apt-get install gcc -y \
-  && apt-get clean
 RUN pip3 install --no-cache-dir web3==5.31.4
 COPY boba_community/fraud-detector/fraud-detector.py /
 COPY boba_community/fraud-detector/packages/jsonrpclib /jsonrpclib


### PR DESCRIPTION

## Overview

In develop, builds have been failing:
```
Status: Downloaded newer image for python:3.8-slim
 ---> d71f65ed6f4b
Step 2/9 : RUN apt-get update   && apt-get install gcc -y   && apt-get clean
 ---> Running in da597486d4a0
Get:1 http://deb.debian.org/debian bookworm InRelease [147 kB]
Get:2 http://deb.debian.org/debian bookworm-updates InRelease [52.1 kB]
Get:3 http://deb.debian.org/debian-security bookworm-security InRelease [48.0 kB]
Get:4 http://deb.debian.org/debian bookworm/main amd64 Packages [8904 kB]
Get:5 http://deb.debian.org/debian-security bookworm-security/main amd64 Packages [28.9 kB]
Fetched 9180 kB in 1s (6867 kB/s)
Reading package lists...
E: Problem executing scripts APT::Update::Post-Invoke 'rm -f /var/cache/apt/archives/*.deb /var/cache/apt/archives/partial/*.deb /var/cache/apt/*.bin || true'
E: Sub-process returned an error code
The command '/bin/sh -c apt-get update   && apt-get install gcc -y   && apt-get clean' returned a non-zero code: 100
Service 'fraud-detector' failed to build : Build failed

```
## Changes

I just tried if everything continues to work without installing gcc separately.

## Testing

/