### PR TITLE
bump python

### DIFF
--- a/.github/workflows/boba-publish-develop.yml
+++ b/.github/workflows/boba-publish-develop.yml
@@ -50,10 +50,16 @@ jobs:
         run: docker --version
       - name: Install Latest Docker
         run: |
-          curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
-          sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu  $(lsb_release -cs)  stable"
           sudo apt-get update
-          sudo apt-get install -y docker-ce
+          sudo apt-get install -y ca-certificates curl gnupg
+          sudo install -m 0755 -d /etc/apt/keyrings
+          curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+          sudo chmod a+r /etc/apt/keyrings/docker.gpg
+          echo \
+            "deb [arch="$(dpkg --print-architecture)" signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \
+            "$(. /etc/os-release && echo "$VERSION_CODENAME")" stable" | \
+            sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+          sudo apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
       - name: Check Docker Version
         run: docker --version
 

--- a/.github/workflows/boba-publish-develop.yml
+++ b/.github/workflows/boba-publish-develop.yml
@@ -1,11 +1,9 @@
 name: Publish Packages (boba-develop)
 
 on:
-  pull_request:
-
-  # push:
-  #   branches:
-  #     - 'develop'
+  push:
+    branches:
+      - 'develop'
 
 jobs:
 
@@ -129,7 +127,7 @@ jobs:
 
       - name: Build the core services
         working-directory: ./ops
-        run: docker-compose build fraud-detector
+        run: docker-compose build
 
       - name: Build the side services
         working-directory: ./ops

--- a/.github/workflows/boba-publish-develop.yml
+++ b/.github/workflows/boba-publish-develop.yml
@@ -1,9 +1,11 @@
 name: Publish Packages (boba-develop)
 
 on:
-  push:
-    branches:
-      - 'develop'
+  pull_request:
+
+  # push:
+  #   branches:
+  #     - 'develop'
 
 jobs:
 
@@ -44,6 +46,17 @@ jobs:
     runs-on: ${{ needs.start-runner.outputs.label }}
 
     steps:
+      - name: Check Docker Version
+        run: docker --version
+      - name: Install Latest Docker
+        run: |
+          curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+          sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu  $(lsb_release -cs)  stable"
+          sudo apt-get update
+          sudo apt-get install -y docker-ce
+      - name: Check Docker Version
+        run: docker --version
+
       - name: Login to Docker Hub
         uses: docker/login-action@v2
         with:
@@ -110,7 +123,7 @@ jobs:
 
       - name: Build the core services
         working-directory: ./ops
-        run: docker-compose build
+        run: docker-compose build fraud-detector
 
       - name: Build the side services
         working-directory: ./ops

--- a/.github/workflows/boba-publish-master.yml
+++ b/.github/workflows/boba-publish-master.yml
@@ -46,6 +46,23 @@ jobs:
       id-token: write
       contents: read
     steps:
+      - name: Check Docker Version
+        run: docker --version
+      - name: Install Latest Docker
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ca-certificates curl gnupg
+          sudo install -m 0755 -d /etc/apt/keyrings
+          curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+          sudo chmod a+r /etc/apt/keyrings/docker.gpg
+          echo \
+            "deb [arch="$(dpkg --print-architecture)" signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \
+            "$(. /etc/os-release && echo "$VERSION_CODENAME")" stable" | \
+            sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+          sudo apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+      - name: Check Docker Version
+        run: docker --version
+
       - name: Login to Docker Hub
         uses: docker/login-action@v2
         with:

--- a/boba_community/fraud-detector/docker/Dockerfile.fraud-detector
+++ b/boba_community/fraud-detector/docker/Dockerfile.fraud-detector
@@ -1,5 +1,5 @@
-FROM python:3.8-slim
-RUN pip3 install --no-cache-dir web3==5.31.4
+FROM python:3.11-slim
+RUN pip3 install --debug --no-cache-dir web3==5.31.4
 COPY boba_community/fraud-detector/fraud-detector.py /
 COPY boba_community/fraud-detector/packages/jsonrpclib /jsonrpclib
 COPY /packages/contracts/artifacts/contracts/L1/rollup/StateCommitmentChain.sol/StateCommitmentChain.json /contracts/StateCommitmentChain.json

--- a/boba_community/fraud-detector/docker/Dockerfile.fraud-detector
+++ b/boba_community/fraud-detector/docker/Dockerfile.fraud-detector
@@ -1,5 +1,5 @@
 FROM python:3.11-slim
-RUN pip3 install --debug --no-cache-dir web3==5.31.4
+RUN pip3 install --no-cache-dir web3==5.31.4
 COPY boba_community/fraud-detector/fraud-detector.py /
 COPY boba_community/fraud-detector/packages/jsonrpclib /jsonrpclib
 COPY /packages/contracts/artifacts/contracts/L1/rollup/StateCommitmentChain.sol/StateCommitmentChain.json /contracts/StateCommitmentChain.json


### PR DESCRIPTION


## Overview

It seems like a specific version of docker + python does not go well together. develop doesn't push images anymore.

## Changes


- Updated docker
- Bumped base layer image for the python node

## Testing

/