### PR TITLE
Require a positive balance for the fee token.

### DIFF
--- a/l2geth/core/state_transition.go
+++ b/l2geth/core/state_transition.go
@@ -48,8 +48,10 @@ The state transitioning model does all the necessary work to work out a valid ne
 3) Create a new state object if the recipient is \0*32
 4) Value transfer
 == If contract creation ==
-  4a) Attempt to run transaction data
-  4b) If valid, use result as code for the new state object
+
+	4a) Attempt to run transaction data
+	4b) If valid, use result as code for the new state object
+
 == end ==
 5) Run Script section
 6) Derive new state root
@@ -277,7 +279,7 @@ func (st *StateTransition) buyGas() error {
 		if !st.isEthereumL2 {
 			bobaval = new(big.Int).Div(bobaval, st.bobaPriceRatioDivisor)
 		}
-		if st.state.GetBobaBalance(st.msg.From()).Cmp(bobaval) < 0 {
+		if st.state.GetBobaBalance(st.msg.From()).Cmp(bobaval) <= 0 {
 			if !st.isEthereumL2 {
 				return errInsufficientL1NativeTokenBalanceForGas
 			}


### PR DESCRIPTION
As per @mmontour1306:

Prevent a transaction from taking the fee-token balance to exactly zero, avoiding scenarios which can result from improper refund calculation associated with its storage slot.

 Changes to be committed:
	modified:   l2geth/core/state_transition.go

:clipboard: Add associated issues, tickets, docs URL here.

Workaround for https://github.com/bobanetwork/boba_prv/issues/8

This is a minimal approach which treats a technically-valid situation as an error (the calculated fee happening to take the user's token balance exactly to zero) but this is not anticipated to have much real-world impact.

## Testing

This can be tested with an integration test, however I have not included one with this checkin because it doesn't work along with the rest of the current test suite.
