### PR TITLE
Fix/ Avax (FUJI) deprecation notice gateway

### DIFF
--- a/packages/boba/gateway/src/components/notificationBanner/bannerConfig.ts
+++ b/packages/boba/gateway/src/components/notificationBanner/bannerConfig.ts
@@ -1,3 +1,5 @@
+import { NETWORK } from 'util/network/network.util'
+
 interface BannerContent {
   message?: string
   content?: string
@@ -14,4 +16,9 @@ interface BannerContent {
  *
  */
 
-export const BannerConfig: Record<string, BannerContent> = {}
+export const BannerConfig: Record<string, BannerContent> = {
+  [NETWORK.AVAX]: {
+    message: `BobaAvax (Fuji) is being wound down & will no longer be available, starting Aug 31st`,
+    content: `BobaAvax (Fuji) is being wound down & will no longer be available starting Aug 31st. For users of BobaAvax or BobaAvax applications you will need to transfer all your funds to Avax mainnet before Aug 15th or risk permanently losing access to any assets on BobaAvax.`,
+  },
+}

--- a/packages/boba/gateway/src/components/notificationBanner/tests/__snapshots__/index.test.tsx.snap
+++ b/packages/boba/gateway/src/components/notificationBanner/tests/__snapshots__/index.test.tsx.snap
@@ -68,7 +68,7 @@ exports[`NotificationBanner  should match snapshot and check show banner when op
       class="c1"
       data-testid="message"
     >
-      BobaOpera is being wound down & will no longer be available, starting June 25th
+      BobaAvax (Fuji) is being wound down & will no longer be available, starting Aug 31st
       <span
         class="c2"
         role="readMore"
@@ -148,7 +148,7 @@ exports[`NotificationBanner  should match snapshot without message 1`] = `
       class="c1"
       data-testid="message"
     >
-      BobaOpera is being wound down & will no longer be available, starting June 25th
+      BobaAvax (Fuji) is being wound down & will no longer be available, starting Aug 31st
       <span
         class="c2"
         role="readMore"

--- a/packages/boba/gateway/src/components/notificationBanner/tests/index.test.tsx
+++ b/packages/boba/gateway/src/components/notificationBanner/tests/index.test.tsx
@@ -9,14 +9,14 @@ import { BannerConfig } from '../bannerConfig'
 
 jest.mock('../bannerConfig', () => ({
   BannerConfig: {
-    FANTOM: {
-      message: `BobaOpera is being wound down & will no longer be available, starting June 25th`,
-      content: `BobaOpera is being wound down & will no longer be available starting June 25th. For users of BobaOpera or BobaOpera applications you will need to transfer all your funds to Fantom mainnet before June 15th or risk permanently losing access to any assets on BobaOpera.`,
+    AVAX: {
+      message: `BobaAvax (Fuji) is being wound down & will no longer be available, starting Aug 31st`,
+      content: `BobaAvax (Fuji) is being wound down & will no longer be available starting Aug 31st. For users of BobaAvax or BobaAvax applications you will need to transfer all your funds to Avax mainnet before Aug 15th or risk permanently losing access to any assets on BobaAvax.`,
     },
   },
 }))
 
-const data = BannerConfig[NETWORK.FANTOM] || {}
+const data = BannerConfig[NETWORK.AVAX] || {}
 
 const mockStore = configureStore()
 
@@ -28,7 +28,7 @@ const renderBanner = (props: any) => {
           theme: 'dark',
         },
         network: {
-          activeNetwork: NETWORK.FANTOM,
+          activeNetwork: NETWORK.AVAX,
           activeNetworkType: NETWORK_TYPE.MAINNET,
         },
       })}

--- a/packages/boba/gateway/src/containers/modals/deposit/steps/BridgeAlert.tsx
+++ b/packages/boba/gateway/src/containers/modals/deposit/steps/BridgeAlert.tsx
@@ -1,0 +1,28 @@
+import { Text } from 'components/global/text'
+import React from 'react'
+import { useSelector } from 'react-redux'
+import { selectActiveNetwork } from 'selectors'
+import styled from 'styled-components'
+
+import { bridgeAlerts } from './alertConfig'
+
+const AlertText = styled(Text)`
+  color: ${(props) => props.theme.warning};
+  font-size: 16px;
+  font-weight: 700;
+  margin: 5px 0px;
+`
+
+const BridgeAlert = () => {
+  const activeNetwork = useSelector(selectActiveNetwork())
+
+  const alertCaption = bridgeAlerts[activeNetwork]
+
+  if (alertCaption) {
+    return <AlertText>{alertCaption}</AlertText>
+  }
+
+  return <></>
+}
+
+export default BridgeAlert

--- a/packages/boba/gateway/src/containers/modals/deposit/steps/InputStep.js
+++ b/packages/boba/gateway/src/containers/modals/deposit/steps/InputStep.js
@@ -18,6 +18,7 @@ import { WrapperActionsModal } from 'components/modal/Modal.styles'
 
 import BN from 'bignumber.js'
 import { ethers } from 'ethers'
+import BridgeAlert from './BridgeAlert'
 
 function InputStep({ handleClose, token, isBridge, openTokenPicker }) {
 
@@ -105,6 +106,7 @@ function InputStep({ handleClose, token, isBridge, openTokenPicker }) {
     //no token in this account
     return (
       <Box>
+        <BridgeAlert />
         <Typography variant="body2" sx={{ fontWeight: 700, my: 1, color: 'yellow' }}>
           Sorry, nothing to deposit - no {token.symbol} in this wallet
         </Typography>
@@ -125,6 +127,7 @@ function InputStep({ handleClose, token, isBridge, openTokenPicker }) {
   return (
     <>
       <Box>
+        <BridgeAlert />
         {!isBridge &&
           <Typography variant="h2" sx={{ fontWeight: 700, mb: 3 }}>
             Classic Bridge {token && token.symbol ? token.symbol : ''} to L2

--- a/packages/boba/gateway/src/containers/modals/deposit/steps/InputStepFast.js
+++ b/packages/boba/gateway/src/containers/modals/deposit/steps/InputStepFast.js
@@ -62,6 +62,7 @@ import {
   fetchL1FeeBalance,
   fetchL2LPLiquidity,
 } from 'actions/balanceAction'
+import BridgeAlert from './BridgeAlert'
 
 
 function InputStepFast({ handleClose, token, isBridge, openTokenPicker }) {
@@ -293,6 +294,7 @@ function InputStepFast({ handleClose, token, isBridge, openTokenPicker }) {
     //no token in this account
     return (
       <Box>
+        <BridgeAlert />
         <Typography
           variant="body2"
           sx={{ fontWeight: 700, mb: 1, color: 'yellow' }}
@@ -317,6 +319,7 @@ function InputStepFast({ handleClose, token, isBridge, openTokenPicker }) {
   return (
     <>
       <Box>
+        <BridgeAlert />
         {!isBridge && (
           <Typography variant="h2" sx={{ fontWeight: 700, mb: 1 }}>
             Fast Bridge to L2

--- a/packages/boba/gateway/src/containers/modals/deposit/steps/alertConfig.ts
+++ b/packages/boba/gateway/src/containers/modals/deposit/steps/alertConfig.ts
@@ -1,0 +1,7 @@
+import { NETWORK } from 'util/network/network.util'
+
+export const bridgeAlerts = {
+  [NETWORK.AVAX]: `For users of BobaAvax (Fuji) or BobaAvax (Fuji) applications
+  you will need to transfer all your funds to Avalanche mainnet before Aug 15th
+  or risk permanently losing access to any assets on BobaAvax (Fuji)`,
+}


### PR DESCRIPTION
:clipboard: Add associated issues, tickets, docs URL here.

## Overview

Changes to show deprecation banner for Avax & Avax Testnet (Fuji) on gateway 

## Changes

Describe your changes and implementation choices. More details make PRs easier to review.

- Added banner with a note about the deprecation of Avax on the gateway.
- Updated the status of the deposit modal for the Avax network.


## Testing

On running a gateway you will notice the banner with the content below on the gateway, when connected to the Avax network.

![Screenshot 2023-07-19 at 4 23 01 PM](https://github.com/bobanetwork/boba/assets/86316370/6ebec776-3efa-4466-8eee-81633a27eb8b)
![Screenshot 2023-07-19 at 4 23 09 PM](https://github.com/bobanetwork/boba/assets/86316370/9e4f6a28-29bd-4b2c-a366-ea1a9bb1caa3)
![Screenshot 2023-07-19 at 4 23 17 PM](https://github.com/bobanetwork/boba/assets/86316370/a5d32f59-510d-47a7-bbf6-cd323ae76e31)

