### PR TITLE
Making getBalance in network services more robust

### DIFF
--- a/packages/boba/gateway/src/services/networkService.js
+++ b/packages/boba/gateway/src/services/networkService.js
@@ -889,7 +889,22 @@ class NetworkService {
         }
       })
 
-      const tokenBalances = await Promise.all(getBalancePromise)
+      const tokenBalances = await Promise.allSettled(getBalancePromise).then(
+        (results) =>
+          results
+            .filter((result) => {
+              switch (result.status) {
+                case 'fulfilled': {
+                  return true
+                }
+                case 'rejected': {
+                  console.log("NS: getBalances:", result.reason)
+                  return false
+                }
+              }
+            })
+            .map((result) => result.value)
+      )
 
       tokenBalances.forEach((token) => {
         if (token.layer === 'L1' &&


### PR DESCRIPTION
## Overview

Small change that prevents getBalance method in network services from ruining user experience in the case of an error.

## Changes

replacing `Promise.all` with `Promise.allSettled` and logging and filtering errors

## Testing

please run locally
