### PR TITLE
fixing issue on Avalanche Icons

### DIFF
--- a/packages/boba/gateway/src/util/coinImage.ts
+++ b/packages/boba/gateway/src/util/coinImage.ts
@@ -4,6 +4,12 @@ import mttLogo from 'assets/images/mtt.png'
 export const getCoinImage = (symbol: string): string => {
   const logoURIbase =
     'https://raw.githubusercontent.com/bobanetwork/token-list/main/assets'
+
+  // hard fox for avax
+  if (symbol.includes('.')) {
+    symbol = symbol.split('.')[0]
+  }
+
   let url = `${logoURIbase}/${symbol?.toLowerCase()}.svg`
 
   if (symbol === 'test') {
@@ -12,5 +18,6 @@ export const getCoinImage = (symbol: string): string => {
   if (symbol === 'mtt') {
     url = mttLogo
   }
+
   return url
 }


### PR DESCRIPTION
Simple hard fix for Avalanche icons on Earn page. 

![image](https://github.com/bobanetwork/boba/assets/81116391/98ce86ad-531e-44a1-aaa4-72f5453ba105)