### PR TITLE
update react-doom activeClassName to className is active #1

### DIFF
--- a/packages/boba/gateway/src/components/layout/Header/NavDrawer/index.tsx
+++ b/packages/boba/gateway/src/components/layout/Header/NavDrawer/index.tsx
@@ -117,7 +117,7 @@ const NavDrawer: FC<Props> = ({ onClose, open }) => {
               <NavLinkItem
                 key={menu.label}
                 to={menu.path}
-                activeclassname="active"
+                className={({ isActive }) => (isActive ? 'active' : '')}
                 onClick={onClose}
               >
                 {menu.label}

--- a/packages/boba/gateway/src/components/layout/Header/Navigation/index.tsx
+++ b/packages/boba/gateway/src/components/layout/Header/Navigation/index.tsx
@@ -43,7 +43,7 @@ const Navigation: FC<MenuProps> = ({ isOpen }) => {
           <NavLinkItem
             key={menu.label}
             to={menu.path}
-            activeclassname="active"
+            className={({ isActive }) => (isActive ? 'active' : '')}
             // onClick={() => isMobile ? setOpen(false) : null}
           >
             {menu.label}


### PR DESCRIPTION
The use of "activeClassName" has been updated based on the new version of React DOM + test coverage has been updated.
