### PR TITLE
chore: Replace Replica RPC with Tenderly RPC

### DIFF
--- a/boba_community/boba-node/docker-compose-goerli.yml
+++ b/boba_community/boba-node/docker-compose-goerli.yml
@@ -15,7 +15,7 @@ services:
       -  ../../ops/envs/dtl.env
     environment:
       << : *l1_rpc_dtl
-      DATA_TRANSPORT_LAYER__L2_RPC_ENDPOINT: https://replica.goerli.boba.network
+      DATA_TRANSPORT_LAYER__L2_RPC_ENDPOINT: https://boba-goerli.gateway.tenderly.co/1clfZoq7qEGyF4SQvF8gvI
       DATA_TRANSPORT_LAYER__SYNC_FROM_L1: 'false'
       DATA_TRANSPORT_LAYER__SYNC_FROM_L2: 'true'
       DATA_TRANSPORT_LAYER__L2_CHAIN_ID: 2888

--- a/boba_community/fraud-detector/docker-compose-goerli.yml
+++ b/boba_community/fraud-detector/docker-compose-goerli.yml
@@ -82,7 +82,7 @@ services:
     environment:
       <<: *l1_node_web3_url
       L1_CONFIRMATIONS: 8
-      L2_NODE_WEB3_URL: https://replica.goerli.boba.network
+      L2_NODE_WEB3_URL: https://boba-goerli.gateway.tenderly.co/1clfZoq7qEGyF4SQvF8gvI
       L2_CHECK_INTERVAL: 10
       VERIFIER_WEB3_URL: http://verifier_l2geth:8545
       ADDRESS_MANAGER_ADDRESS: '0x6FF9c8FF8F0B6a0763a3030540c21aFC721A9148'

--- a/boba_community/hc-captcha-faucet-2023/captcha.py
+++ b/boba_community/hc-captcha-faucet-2023/captcha.py
@@ -115,7 +115,7 @@ ERC20_CONTRACT_ADDR = "0x4200000000000000000000000000000000000023"  # token (BOB
 
 SUPPORTED_NETWORKS = {
   "BOBA_BNB_TESTNET": "https://replica.testnet.bnb.boba.network",
-  "BOBA_GOERLI_TESTNET": "https://replica.goerli.boba.network",
+  "BOBA_GOERLI_TESTNET": "https://boba-goerli.gateway.tenderly.co/1clfZoq7qEGyF4SQvF8gvI",
   "BOBA_AVAX_TESTNET": "https://replica.testnet.avax.boba.network",
 }
 

--- a/packages/boba/subgraph/README.md
+++ b/packages/boba/subgraph/README.md
@@ -91,7 +91,7 @@ Here is some example queries to get you started:
 
 ## Local setup
 
-1. Run local hardhat node and fork network: `npx hardhat node --fork https://replica.goerli.boba.network --hostname 0.0.0.0`
+1. Run local hardhat node and fork network: `npx hardhat node --fork https://boba-goerli.gateway.tenderly.co/1clfZoq7qEGyF4SQvF8gvI --hostname 0.0.0.0`
 2. Clone [graph-node](https://github.com/graphprotocol/graph-node)
 3. Replace `mainnet:` with `boba:` in the `ethereum:` property.
 4. Run `docker-compose up` in the `./docker` directory of the repo.

--- a/packages/boba/teleportation/src/utils/chains.ts
+++ b/packages/boba/teleportation/src/utils/chains.ts
@@ -51,7 +51,7 @@ export const BobaChains: IBobaChains = {
     },
   },
   2888: {
-    url: 'https://replica.goerli.boba.network',
+    url: 'https://boba-goerli.gateway.tenderly.co/1clfZoq7qEGyF4SQvF8gvI',
     testnet: true,
     name: 'Boba Ethereum Goerli',
     teleportationAddress: '0xB43EE846Aa266228FeABaD1191D6cB2eD9808894',


### PR DESCRIPTION
## Overview

Boba Goerli is out from Tenderly.

## Changes

- Replace Replica RPC with Tenderly.
