### PR TITLE
feat: Migration from TheGraph to GoldSky for LightBridge

### DIFF
--- a/packages/boba/subgraph/L2/package.json
+++ b/packages/boba/subgraph/L2/package.json
@@ -11,7 +11,8 @@
     "create:subgraph:goerli": "graph create --node https://graph.goerli.boba.network:8020 boba/Bridges",
     "deploy:subgraph:local": "graph deploy boba/Bridges --ipfs http://127.0.0.1:5001 --node http://127.0.0.1:8020",
     "deploy:subgraph:goerli": "graph deploy boba/Bridges --ipfs https://graph.goerli.boba.network:5001 --node https://graph.goerli.boba.network:8020",
-    "deploy:subgraph:mainnet": "graph deploy --product hosted-service BOBANETWORK/boba-l2-subgraph"
+    "deploy:subgraph:mainnet": "graph deploy --product hosted-service BOBANETWORK/boba-l2-subgraph",
+    "deploy:goldsky": "goldsky subgraph deploy light-bridge/v1 --from-abi ./subgraph.json"
   },
   "devDependencies": {
     "@graphprotocol/graph-cli": "^0.55.0",

--- a/packages/boba/subgraph/L2/subgraph.json
+++ b/packages/boba/subgraph/L2/subgraph.json
@@ -1,0 +1,48 @@
+{
+  "version": "1",
+  "name": "light-bridge",
+  "abis": {
+    "Teleportation": {
+      "path": "./abis/Teleportation.json"
+    }
+  },
+  "chains": ["arbitrum-goerli", "chapel", "boba-bnb-testnet", "boba-goerli", "goerli", "optimism-goerli"],
+  "instances": [
+    {
+      "abi": "Teleportation",
+      "address": "0x7f6a32bCaA70c65E08F2f221737612F6fC18347A",
+      "startBlock": 32272487,
+      "chain": "chapel"
+    },
+    {
+      "abi": "Teleportation",
+      "address": "0x84b22166366a6f7E0cD0c3ce9998f2913Bf17A13",
+      "startBlock": 9484025,
+      "chain": "goerli"
+    },
+    {
+      "abi": "Teleportation",
+      "address": "0xC226F132A686A08018431C913d87693396246024",
+      "startBlock": 17010097,
+      "chain": "optimism-goerli"
+    },
+    {
+      "abi": "Teleportation",
+      "address": "0x7063f59e1Db3e505D844d11A71C78F92D39E5963",
+      "startBlock": 53880808,
+      "chain": "arbitrum-goerli"
+    },
+    {
+      "abi": "Teleportation",
+      "address": "0xf4d179d3a083Fa3Eede935FaF4C679D32d514186",
+      "startBlock": 295353,
+      "chain": "boba-bnb-testnet"
+    },
+    {
+      "abi": "Teleportation",
+      "address": "0xB43EE846Aa266228FeABaD1191D6cB2eD9808894",
+      "startBlock": 40822,
+      "chain": "boba-goerli"
+    }
+  ]
+}

--- a/packages/boba/subgraph/README.md
+++ b/packages/boba/subgraph/README.md
@@ -1,3 +1,13 @@
+# Goldsky migration
+Light bridge has been migrated to Goldsky, more contracts may follow (we may need to evaluate which subgraphs are still needed).
+
+You need only one config file: `subgraph.json`
+This one has to be adapted manually, but the rest is automized.
+
+Just execute `goldsky subgraph deploy light-bridge/v{VERSION} --from-abi ./subgraph.json` to deploy the subgraphs on all supported networks.
+
+---
+
 # Boba Network Subgraphs
 
 These subgraphs index the **StandardBridge**, the **LiquidityPool**, the **Boba DAO**, and the **TuringMonster** contracts.

--- a/packages/boba/teleportation/src/utils/chains.ts
+++ b/packages/boba/teleportation/src/utils/chains.ts
@@ -27,7 +27,6 @@ export const BobaChains: IBobaChains = {
 
   //#region boba_networks
   288: {
-    // TODO: seemingly no public graph node available (would require hosted_service or deploying it ourselves) --> boba listed though, but requires a hosted service
     url: process.env.TELEPORTATION_RPC_BOBAETHMAINNET ?? 'https://boba-ethereum.gateway.tenderly.co',
     testnet: false,
     name: 'Boba Ethereum Mainnet',
@@ -41,7 +40,6 @@ export const BobaChains: IBobaChains = {
     },
   },
   56288: {
-    // TODO: seemingly no public graph node available (would require hosted_service or deploying it ourselves)
     url: process.env.TELEPORTATION_RPC_BOBABNBMAINNET ?? 'https://replica.bnb.boba.network',
     testnet: false,
     name: 'Boba BNB Mainnet',
@@ -53,7 +51,7 @@ export const BobaChains: IBobaChains = {
     },
   },
   2888: {
-    // TODO: seemingly no public graph node available (would require hosted_service or deploying it ourselves)
+    // GoldSky GraphQL endpoint:  https://api.goldsky.com/api/public/project_clq6jph4q9t2p01uja7p1f0c3/subgraphs/light-bridge-boba-goerli/v1/gn
     url: process.env.TELEPORTATION_RPC_BOBAETHGOERLI ?? 'https://replica.goerli.boba.network',
     testnet: true,
     name: 'Boba Ethereum Goerli',
@@ -65,7 +63,7 @@ export const BobaChains: IBobaChains = {
     },
   },
   9728: {
-    // TODO: seemingly no public graph node available (would require hosted_service or deploying it ourselves)
+    // GoldSky GraphQL endpoint:  https://api.goldsky.com/api/public/project_clq6jph4q9t2p01uja7p1f0c3/subgraphs/light-bridge-boba-bnb-testnet/v1/gn
     url: process.env.TELEPORTATION_RPC_BOBABNBTESTNET ?? 'https://boba-bnb-testnet.gateway.tenderly.co',
     testnet: true,
     name: 'Boba BNB Testnet',
@@ -78,6 +76,7 @@ export const BobaChains: IBobaChains = {
     },
   },
   421613: {
+    // GoldSky GraphQL endpoint: https://api.goldsky.com/api/public/project_clq6jph4q9t2p01uja7p1f0c3/subgraphs/light-bridge-arbitrum-goerli/v1/gn
     url: process.env.TELEPORTATION_RPC_ARBITRUMGOERLI ?? 'https://arbitrum-goerli.public.blastapi.io',
     testnet: true,
     name: 'Arbitrum Goerli',
@@ -88,6 +87,7 @@ export const BobaChains: IBobaChains = {
     },
   },
   420: {
+    // GoldSky GraphQL endpoint: https://api.goldsky.com/api/public/project_clq6jph4q9t2p01uja7p1f0c3/subgraphs/light-bridge-optimism-goerli/v1/gn
     url: process.env.TELEPORTATION_RPC_OPTIMISMGOERLI ?? 'https://optimism-goerli.publicnode.com',
     testnet: true,
     name: 'Optimism Goerli',
@@ -98,7 +98,6 @@ export const BobaChains: IBobaChains = {
     },
   },
   42161: {
-    // TODO: seemingly no public graph node available (would require hosted_service or deploying it ourselves)
     url: process.env.TELEPORTATION_RPC_ARBITRUMMAINNET ?? 'https://arbitrum.llamarpc.com',
     testnet: false,
     name: 'Arbitrum Mainnet',
@@ -109,7 +108,6 @@ export const BobaChains: IBobaChains = {
     },
   },
   10: {
-    // TODO: seemingly no public graph node available (would require hosted_service or deploying it ourselves)
     url: process.env.TELEPORTATION_RPC_OPTIMISMMAINNET ?? 'https://optimism.llamarpc.com',
     testnet: false,
     name: 'Optimism Mainnet',
@@ -122,7 +120,6 @@ export const BobaChains: IBobaChains = {
   //#endregion
   //#region l1
   1: {
-    // TODO: Public nodes available, deploy once contract is live
     url: process.env.TELEPORTATION_RPC_ETHMAINNET ?? 'https://eth.llamarpc.com',
     testnet: false,
     name: 'Ethereum Mainnet',
@@ -136,7 +133,6 @@ export const BobaChains: IBobaChains = {
     },
   },
   56: {
-    // TODO: Public nodes available, deploy once contract is live
     url: process.env.TELEPORTATION_RPC_BNBMAINNET ?? 'https://rpc.ankr.com/bsc',
     testnet: false,
     name: 'BNB Mainnet',
@@ -150,7 +146,7 @@ export const BobaChains: IBobaChains = {
     },
   },
   5: {
-    // TODO: DEV VERSION (GRT tokens needed): subgraph deployed: https://api.studio.thegraph.com/query/57436/boba_bridges/version/latest
+    // GoldSky GraphQL endpoint: https://api.goldsky.com/api/public/project_clq6jph4q9t2p01uja7p1f0c3/subgraphs/light-bridge-goerli/v1/gn
     url: process.env.TELEPORTATION_RPC_GOERLITESTNET ?? 'https://rpc.ankr.com/eth_goerli',
     testnet: true,
     name: 'Goerli Testnet',
@@ -164,7 +160,7 @@ export const BobaChains: IBobaChains = {
     },
   },
   97: {
-    // TODO: seemingly no public graph node available (would require hosted_service or deploying it ourselves)
+    // GoldSky GraphQL endpoint:  https://api.goldsky.com/api/public/project_clq6jph4q9t2p01uja7p1f0c3/subgraphs/light-bridge-chapel/v1/gn
     url: process.env.TELEPORTATION_RPC_BNBTESTNET ?? 'https://api.zan.top/node/v1/bsc/testnet/public',
     testnet: true,
     name: 'BNB Testnet',


### PR DESCRIPTION
:clipboard: Associated with: https://github.com/bobanetwork/gateway/pull/240

**Did it in this repository, since we seemingly don't have this package in v3-boba yet. After this is being reviewed & merged I will add it to a suitable place in v3-boba**

## Overview

Migrate from TheGraph to GoldSky for LightBridge. 
Not touching other subgraphs yet, since I would like to check which ones we are still using. 

## Changes

- Adding GoldSky config file for light bridge subgraphs
- Documentation
- Network configs for subgraph deployments
- ChainList endpoints updated

## Testing

Subgraphs successfully deployed and integrated into gateway.

![image](https://github.com/bobanetwork/boba/assets/28724551/8326302c-abc3-40fa-bcd8-e040b6a8ca3e)

