### PR TITLE
Update the image tag and remove geth support for BOBA sepolia

### DIFF
--- a/for-developers/node-operators/snapshot-downloads.md
+++ b/for-developers/node-operators/snapshot-downloads.md
@@ -11,7 +11,7 @@ Always verify snapshots by comparing the sha256sum of the downloaded file to the
 | Client | Snapshot Date | Size  | Download Link                                                | sha256sum                                                    |
 | ------ | ------------- | ----- | ------------------------------------------------------------ | ------------------------------------------------------------ |
 | Erigon | 2024-01-18    | 912KB | [Link](https://boba-db.s3.us-east-2.amazonaws.com/sepolia/boba-sepolia-erigon-db.tgz) | `b887d2e0318e9299e844da7d39ca32040e3d0fb6a9d7abe2dd2f8624eca1cade` |
-| Geth   | 2024-01-18    | 2MB   | [Link](https://boba-db.s3.us-east-2.amazonaws.com/sepolia/boba-sepolia-geth-db.tgz) | `713c10e3232fad373ab77b751c2c17fb4d73540b3496d298507dfd3f823d6a5f` |
+| Geth   | 2024-01-18    | 2MB   | [Link](https://boba-db.s3.us-east-2.amazonaws.com/sepolia/boba-sepolia-geth-db.tgz) | `b229c8e51e41a26bb21a84b329d3134ae5cc6541b04eb160aebd573f0e6b94ae` |
 
 ### BOBA Sepolia Testnet (Legacy)
 

--- a/for-developers/node-operators/software-release.md
+++ b/for-developers/node-operators/software-release.md
@@ -10,9 +10,33 @@ These are the minimal required versions for the `op-node`, `op-erigon` and `op-g
 
 | Network      | op-node                                                      | op-erigon                                                    | op-geth                                                      |
 | ------------ | ------------------------------------------------------------ | ------------------------------------------------------------ | ------------------------------------------------------------ |
-| Boba Sepolia | [v1.5.0](https://github.com/bobanetwork/v3-anchorage/releases/tag/op-node%2Fv1.5.0) | [v0.2.2](https://github.com/bobanetwork/v3-erigon/releases/tag/v0.2.2) | [v1.101305.3](https://github.com/ethereum-optimism/op-geth/releases/tag/v1.101305.3) |
+| Boba Sepolia | [v1.6.1](https://github.com/bobanetwork/v3-anchorage/releases/tag/op-node%2Fv1.6.1) | [v1.1.0](https://github.com/bobanetwork/v3-erigon/releases/tag/v1.1.0) | TBD                                                          |
 | Op Sepolia   | [v1.6.0](https://github.com/bobanetwork/v3-anchorage/releases/tag/v1.6.0) | [v1.0.0](https://github.com/bobanetwork/v3-erigon/releases/tag/v1.0.0) | [v1.101308.1](https://github.com/ethereum-optimism/op-geth/releases/tag/v1.101308.1) |
 | Op Mainnet   | [v1.6.0](https://github.com/bobanetwork/v3-anchorage/releases/tag/v1.6.0) | [v1.0.0](https://github.com/bobanetwork/v3-erigon/releases/tag/v1.0.0) | [v1.101308.1](https://github.com/ethereum-optimism/op-geth/releases/tag/v1.101308.1) |
+
+## [op-node v1.6.1](https://github.com/bobanetwork/v3-anchorage/releases/tag/v1.6.1)
+
+**Description**
+
+This is a mandatory release for node operators on Boba Sepolia networks. The **Ecotone** and **Delta** protocol upgrades will activate on Wed Feb 28 2024 00:00:00 UTC 2024 on Sepolia Boba Chains.
+
+**Required Action**
+
+Upgrade your `op-node` software.
+
+**Suggested action**
+
+Explicitly specify the Beacon endpoint: `--l1.beacon` and `$OP_NODE_L1_BEACON`
+
+## [op-erigon v1.1.0](https://github.com/bobanetwork/v3-erigon/releases/tag/v1.1.0)
+
+**Description**
+
+This is a mandatory release for node operators on Boba Sepolia networks. The **Ecotone** and **Delta** protocol upgrades will activate on Wed Feb 28 2024 00:00:00 UTC 2024 on Sepolia Boba Chains.
+
+**Required Action**
+
+Upgrade your `op-erigon` software.
 
 ## [op-node v1.6.0](https://github.com/bobanetwork/v3-anchorage/releases/tag/v1.6.0)
 
@@ -47,52 +71,3 @@ This is a mandatory release for node operators on Op networks.
 **Required Action**
 
 * Upgrade your `op-geth` software.
-
-## [op-node v1.5.0](https://github.com/bobanetwork/v3-anchorage/releases/tag/op-node%2Fv1.5.0)
-
-**Description**
-
-This is a mandatory release for node operators on Sepolia. It includes three protocol activiations:
-
-* Regolith activates on Sepolia at Thu Jan 18 17:59:48 UTC 2024
-
-* Canyon activates on Sepolia at Thu Jan 18 17:59:48 UTC 2024
-* Shanghai activates on Sepolia at Thu Jan 18 17:59:48 UTC 2024
-
-**Required Action**
-
-Upgrade your `op-node` software.
-
-**Suggested action**
-
-Explicitly specify `--network=boba-sepolia` with a pre-configured BOBA network
-
-## [op-erigon v0.2.2](https://github.com/bobanetwork/v3-erigon/releases/tag/v0.2.2)
-
-**Description**
-
-This is a mandatory release for node operators on Sepolia. It includes three protocol activiations:
-
-* Regolith activates on Sepolia at Thu Jan 18 17:59:48 UTC 2024
-
-* Canyon activates on Sepolia at Thu Jan 18 17:59:48 UTC 2024
-* Shanghai activates on Sepolia at Thu Jan 18 17:59:48 UTC 2024
-
-**Required Action**
-
-Upgrade your `op-erigon` software.
-
-**Suggested action**
-
-Explicitly specify `--chain=boba-sepolia` with a pre-configured BOBA network
-
-## [op-geth v1.101305.3](https://github.com/ethereum-optimism/op-geth/releases/tag/v1.101305.3)
-
-**Description**
-
-This is a mandatory release for node operators on Sepolia.
-
-**Required Action**
-
-* Upgrade your `op-geth` software.
-* Set `--networkid=28882`

--- a/for-developers/node-operators/software-release.md
+++ b/for-developers/node-operators/software-release.md
@@ -10,7 +10,7 @@ These are the minimal required versions for the `op-node`, `op-erigon` and `op-g
 
 | Network      | op-node                                                      | op-erigon                                                    | op-geth                                                      |
 | ------------ | ------------------------------------------------------------ | ------------------------------------------------------------ | ------------------------------------------------------------ |
-| Boba Sepolia | [v1.6.1](https://github.com/bobanetwork/v3-anchorage/releases/tag/op-node%2Fv1.6.1) | [v1.1.0](https://github.com/bobanetwork/v3-erigon/releases/tag/v1.1.0) | TBD                                                          |
+| Boba Sepolia | [v1.6.1](https://github.com/bobanetwork/v3-anchorage/releases/tag/op-node%2Fv1.6.1) | [v1.1.0](https://github.com/bobanetwork/v3-erigon/releases/tag/v1.1.0) | [v1.101308.1](https://github.com/ethereum-optimism/op-geth/releases/tag/v1.101308.1) |
 | Op Sepolia   | [v1.6.0](https://github.com/bobanetwork/v3-anchorage/releases/tag/v1.6.0) | [v1.0.0](https://github.com/bobanetwork/v3-erigon/releases/tag/v1.0.0) | [v1.101308.1](https://github.com/ethereum-optimism/op-geth/releases/tag/v1.101308.1) |
 | Op Mainnet   | [v1.6.0](https://github.com/bobanetwork/v3-anchorage/releases/tag/v1.6.0) | [v1.0.0](https://github.com/bobanetwork/v3-erigon/releases/tag/v1.0.0) | [v1.101308.1](https://github.com/ethereum-optimism/op-geth/releases/tag/v1.101308.1) |
 


### PR DESCRIPTION
Update the required version for Boba Sepolia Testnet.