### PR TITLE
Bump up node version to v18

### DIFF
--- a/ops/docker/hardhat/Dockerfile
+++ b/ops/docker/hardhat/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16-alpine
+FROM node:18-alpine
 
 # bring in the config files for installing deps
 COPY [ \


### PR DESCRIPTION
Fix the build of the hardhat l1 image
```
error @nomicfoundation/ethereumjs-tx@5.0.4: The engine "node" is incompatible with this module. Expected version ">=18". Got "16.20.2"
```
